### PR TITLE
[New Chapters] Add 3 industry-leading datasets.--wip

### DIFF
--- a/docs/en/part12/ch44_fineweb_redpajama_dclm.md
+++ b/docs/en/part12/ch44_fineweb_redpajama_dclm.md
@@ -1,0 +1,348 @@
+# Chapter 44: FineWeb Pre-training Corpus Data Engineering
+
+## Abstract
+
+FineWeb is a large-scale English Web pre-training corpus built by the Hugging Face team from Common Crawl. Its value lies not only in scale, but also in turning "how to transform Web snapshots into training data" into a reproducible engineering chain: reading raw WARC pages, filtering risky URLs, extracting main text with Trafilatura, identifying language with FastText, applying Gopher/C4/FineWeb quality filters, performing per-crawl MinHash deduplication, formatting PII, and publishing data versions. The FineWeb paper also releases the processing code, the DataTrove processing library, and ablation models, allowing data-processing choices to be validated through training outcomes rather than only through manual inspection or heuristic judgment.
+
+The central thread of this chapter is the "refining process" of Web pre-training corpora. Common Crawl provides Web snapshots, but a trainable token stream still requires main-text extraction, language identification, quality filtering, deduplication, privacy processing, and evaluation ablations. FineWeb's value is not only its 15T-token scale, but also the fact that these choices are made executable and experimentally comparable: text extraction and filtering should be validated through downstream training results; the deduplication scope should be judged by its distributional impact rather than only by the deletion ratio; and public corpora should explain data, code, field annotations, and usage boundaries together.
+
+## Keywords
+
+FineWeb; Common Crawl; DataTrove; WARC; Trafilatura; FastText; MinHash; quality filtering; pre-training corpus; data ablation
+
+## 44.0 Learning Objectives
+
+After completing this chapter, readers should be able to:
+
+- Distinguish Common Crawl WARC files, WET text files, extracted Web-page text, filtered FineWeb documents, and the final token stream.
+- Explain why FineWeb re-extracts text from WARC instead of directly using Common Crawl WET text.
+- Understand the data-engineering roles of `WarcReader`, `URLFilter`, `Trafilatura`, `LanguageFilter`, `GopherRepetitionFilter`, `GopherQualityFilter`, `C4QualityFilter`, `FineWebQualityFilter`, `MinhashDedup*`, and `PIIFormatter` in the official FineWeb processing script.
+- Design a Web pre-training document schema that allows each sample to be traced to its source, filters, deduplication state, token statistics, and privacy-processing status.
+- Compare different data-processing strategies under fixed model scale, fixed token budget, fixed evaluation sets, and repeated random seeds.
+- Identify copyright, privacy, removal, evaluation-contamination, and cross-lingual transfer boundaries when adapting FineWeb-style processing to enterprise or research projects.
+
+## Opening Scenario
+
+A team is preparing to train an English foundation model at the 7B-parameter scale. The first data plan is straightforward: download recent Common Crawl WET files, filter non-English pages, run simple deduplication, and send the text into the tokenizer. Offline samples look decent: many pages are indeed natural language, and the token volume is large enough. The team starts small-model pre-training, but after several weeks it encounters three hard-to-explain problems.
+
+First, the model does not improve stably on several commonsense tasks as training progresses. When the team inspects training snippets, it finds that many texts are actually Web menus, footers, cookie banners, SEO keyword lists, and automatically generated on-site recommendations. Second, the same classes of template pages repeatedly appear across months and sites. Training loss seems stable, but model outputs become increasingly prone to repeating templated short phrases. Third, the legal team asks the data team to locate samples from a particular domain and suspected email addresses, but the data team can only fuzzy-search already shuffled token shards; it cannot reconstruct which crawl dump and URL a text came from, which filters it passed, or whether it was retained after deduplication.
+
+These three problems show that Common Crawl is a Web snapshot, not a training set. The real data-engineering task is not to "download more Web pages," but to transform each Web sample into a traceable, filterable, deduplicable, evaluable, and removable training record. FineWeb is a public case study built around exactly this problem.
+
+## 44.1 Common Crawl Is a Web Snapshot, Not a Training Corpus
+
+Common Crawl WARC files preserve the original responses captured during Web crawling, including HTML, request metadata, and page structure. WET files are Common Crawl's extracted text version. For pre-training data engineering, WET is attractive: it avoids HTML parsing cost and has a size closer to the text needed for model training. However, FineWeb's experiments found that directly using WET leaves too much boilerplate, menu text, and page noise, so FineWeb re-extracts main text from WARC.
+
+### 44.1.1 Processing Layers from Web Snapshot to Training Text
+
+At least five transformation layers separate Web snapshots from training text.
+
+The first layer is URL-level filtering. Some domains, paths, or subword patterns carry high risk by themselves, such as malicious sites, adult-content sites, or obvious spam pages. The official FineWeb dataset card places URL filtering at the first step of the pipeline, using block lists and subword detection to remove documents from malicious and NSFW websites.
+
+The second layer is main-text extraction. An HTML page is not the main text; navigation, footers, scripts, recommendation lists, and advertisements may all be mixed into it. FineWeb uses Trafilatura to extract main text from raw WARC HTML, and the paper compares WARC+Trafilatura with WET through ablation experiments.
+
+The third layer is language identification. FineWeb is an English corpus, so it uses FastText language filtering and retains documents whose English score reaches a threshold. The official dataset card states that FineWeb removes documents whose `en` language score is below 0.65.
+
+The fourth layer is quality filtering. Web text commonly contains repeated n-grams, abnormal line lengths, too many short lines, list-like pages, and formatting errors. FineWeb combines Gopher repetition and quality filters, part of the C4 filters, and FineWeb-specific filters to control these problems.
+
+The fifth layer is deduplication and privacy processing. FineWeb performs MinHash deduplication independently within each crawl and uses `PIIFormatter` during public release to anonymize email addresses and public IP addresses.
+
+Together, these steps are not merely a collection of cleaning scripts, but a set of pre-training data contracts. Each step should have inputs, outputs, failure records, and reviewable parameters.
+
+### 44.1.2 Filtering Strength Determines the Training Signal
+
+Web-corpus cleaning most easily produces two opposite errors.
+
+If filtering is too weak, the model absorbs templates, garbled text, advertisements, duplicate pages, and non-natural language. These may contribute many tokens statistically, but they do not help downstream tasks and may even damage the language distribution. If filtering is too strict, corpus size drops, content coverage narrows, and some long-tail knowledge, forum Q&A, and non-standard writing may be mistakenly removed. For pre-training, a filter is not better simply because it is stricter; it must find a verifiable balance between preserving the token budget and improving the training signal.
+
+This trade-off can be described with a simple training-utility function:
+
+$$
+U(F)=S_{eval}(D_F)-\lambda \cdot R_{risk}(D_F)-\mu \cdot \max(0, T_{target}-T_F)
+$$
+
+Here, $F$ denotes the filtering strategy, $D_F$ is the filtered dataset, $S_{eval}$ is the model score under a fixed evaluation protocol, $R_{risk}$ is privacy, copyright, toxicity, and contamination risk, $T_F$ is the retained token count, and $T_{target}$ is the lower token bound required by the training budget. This is not an original formula from the FineWeb paper; it is an engineering abstraction of the FineWeb experimental logic: when selecting filters, one cannot look only at whether samples appear "clean"; one must also evaluate whether the model improves under a fixed training budget and whether risk decreases.
+
+## 44.2 FineWeb Data Definition and Public Form
+
+FineWeb is publicly available as a full dataset, configurations split by Common Crawl dump, and smaller sample versions. The official dataset card states that users can load the full dataset or specify a particular crawl/dump; dump names follow the `CC-MAIN-(year)-(week number)` format. Sample versions include random subsets of approximately 350B, 100B, and 10B GPT-2 tokens, enabling researchers to reproduce experiments or debug processing code at lower cost.
+
+*Table 44-1 Public FineWeb Forms and Engineering Uses*
+
+| Form | Public Description | Engineering Use | Usage Notes |
+| --- | ---: | --- | --- |
+| FineWeb full dataset | The initial paper reports 15T tokens; the official dataset card continues listing later dumps | Large-scale English Web pre-training, data ablation, filtering-strategy research | The data continues to update; cite the dataset-card access time and scale convention |
+| Per-dump config | Organized as `CC-MAIN-YYYY-WW` | Sampling by time window, reproducing experiments, locating distribution shifts | Different dumps differ in site coverage and quality; do not assume identical distributions |
+| `sample-350BT` | Approximately 350B GPT-2 tokens | Medium-scale data experiments, deduplication and filtering validation | Suitable for larger ablations, but not equivalent to full FineWeb |
+| `sample-100BT` | Approximately 100B GPT-2 tokens | Prototype training, quick evaluation, cost-constrained experiments | Record sampling source and randomness |
+| `sample-10BT` | Approximately 10B GPT-2 tokens | Pipeline debugging, field checks, read/write performance tests | Not suitable for final data-quality conclusions |
+
+Sources: Hugging Face FineWeb dataset card download configurations, sample-version descriptions, and dump naming convention; initial scale reported by the FineWeb paper.
+
+### 44.2.1 Task Definition
+
+FineWeb's task is not to annotate supervised-learning labels, but to build a pre-training token stream for autoregressive language models. Given a collection of Common Crawl Web snapshots $C=\{c_i\}$, the goal is to learn a data-processing function:
+
+$$
+P_\theta: C \rightarrow D=\{d_j\}
+$$
+
+Each output document $d_j$ should at least include extracted text, source metadata, language information, token statistics, filtering status, and deduplication status. The tokenizer then maps the document collection into training sequences:
+
+$$
+\tau(D)=\left[x_1,x_2,\ldots,x_N\right]
+$$
+
+The standard pre-training objective remains minimizing next-token negative log likelihood:
+
+$$
+\mathcal{L}(\theta)=-\sum_{t=1}^{N}\log p_\theta(x_t|x_{<t})
+$$
+
+FineWeb focuses on the part before this objective function: how to choose $P_\theta$ so that, under the same model, the same training tokens, and the same evaluation sets, the resulting model is better.
+
+FineWeb leaves engineering teams with three main judgments. The first concerns main-text extraction. WET text is already "text," but not necessarily "trainable main text." FineWeb's replacement of WET with WARC+Trafilatura shows that text extraction itself must be treated as a core variable affecting model capability.
+
+The second concerns deduplication granularity. Global deduplication appears more thorough, but FineWeb's ablation results show that running global MinHash deduplication across all crawls is not necessarily better; independent per-crawl deduplication performs more strongly. This reminds data-engineering teams that the goal of deduplication is not to remove the maximum possible repetition, but to remove repetition that harms training.
+
+The third concerns filter validation. FineWeb does not choose filters solely from manual rules. Instead, it trains multiple data-ablation models and compares scores on fixed evaluation sets. Filter thresholds, C4-rule choices, and custom heuristics are determined through training validation.
+
+## 44.3 Key Fields in FineWeb Document Records
+
+The official FineWeb dataset card states that samples include `language`, `language_score`, and `token_count` annotations, derived respectively from the language filter and GPT-2 tokenizer statistics. When reproducing a FineWeb-like pipeline inside an enterprise, processing status, provenance, deduplication, and risk fields should also be retained. Otherwise, when training results become abnormal, it is impossible to determine whether the issue came from extraction, filtering, deduplication, or sampling.
+
+*Table 44-2 FineWeb-like Web Document Record Schema*
+
+| Field Group | Typical Fields | Source or Generation Method | Engineering Use |
+| --- | --- | --- | --- |
+| Provenance fields | `url`, `dump`, `warc_record_id`, `fetch_time` | WARC metadata and reader supplements | Trace original Web pages, locate crawls, respond to removals |
+| Text fields | `text`, `raw_html_hash`, `text_hash` | Trafilatura extraction and hash computation | Support training reads, extraction-quality checks, and precise location |
+| Language fields | `language`, `language_score` | FastText `LanguageFilter` | Control English-corpus boundary and diagnose language-identification errors |
+| Quality fields | `gopher_flags`, `c4_flags`, `fineweb_flags` | Gopher, C4, and FineWeb filters | Explain why a sample was retained or removed |
+| Dedup fields | `minhash_signature`, `dedup_cluster_id`, `dedup_keep` | MinHash deduplication stage | Control near-duplicates and review removed samples |
+| Statistics fields | `token_count`, `char_count`, `line_count` | `TokensCounter` and document statistics | Estimate training budget and analyze filtering impact |
+| Privacy fields | `pii_email_replaced`, `pii_ip_replaced` | `PIIFormatter` | Record email and public-IP anonymization status |
+
+Fields such as `gopher_flags`, `c4_flags`, and `fineweb_flags` are field groups added by the author to explain the engineering structure; they do not imply that the official FineWeb dataset card publishes each of these columns. The official annotations explicitly published by FineWeb include `language`, `language_score`, and `token_count`.
+
+### 44.3.1 A Sample Cannot Store Only `text`
+
+The following is an abstract FineWeb-like document record. It is not an original FineWeb sample; it is an engineering example organized from the FineWeb dataset card and the DataTrove pipeline.
+
+```json
+{
+  "id": "CC-MAIN-2023-50/segment-x/warc-record-y",
+  "url": "https://example.org/article",
+  "dump": "CC-MAIN-2023-50",
+  "text": "<main text extracted by Trafilatura>",
+  "language": "en",
+  "language_score": 0.94,
+  "token_count": 1267,
+  "filters": {
+    "url_filter": "kept",
+    "gopher_repetition": "kept",
+    "gopher_quality": "kept",
+    "c4_quality": "kept",
+    "fineweb_quality": "kept"
+  },
+  "dedup": {
+    "method": "minhash",
+    "scope": "per_dump",
+    "ngram": 5,
+    "buckets": 14,
+    "hashes_per_bucket": 8,
+    "keep": true
+  },
+  "pii": {
+    "email_formatted": true,
+    "public_ip_formatted": true
+  }
+}
+```
+
+This example illustrates the basic idea of a FineWeb-like corpus: `text` is the training entry point, but by itself it cannot explain sample quality. What supports review is the combination of provenance, language score, filtering status, deduplication scope, and privacy-processing records.
+
+### 44.3.2 Relationship Between Schema and Training Evaluation
+
+FineWeb does not evaluate individual samples directly; it evaluates data versions generated by processing strategies. Let a processing version $v$ correspond to dataset $D_v$, which is used to train model $M_v$. If the evaluation suite is $B=\{b_1,\ldots,b_k\}$ and each task score is $s(M_v,b_i)$, an aggregate score can be defined as:
+
+$$
+S(M_v)=\frac{1}{k}\sum_{i=1}^{k}s(M_v,b_i)
+$$
+
+The FineWeb paper compares data versions using fixed models, fixed training tokens, fixed evaluation tasks, repeated random samples, and different initialization seeds. In engineering practice, each data version should further record its processing manifest:
+
+$$
+Manifest(v)=\{code\_commit, dump\_set, filter\_params, dedup\_params, tokenizer, sample\_seed\}
+$$
+
+Without this manifest, even if the evaluation script is reproduced, one cannot reproduce "which exact data version was trained."
+
+## 44.4 FineWeb's Code-based Processing Flow
+
+One important feature of FineWeb is that its processing pipeline has a public script. `examples/fineweb.py` in the DataTrove repository states that it is used to process and create the FineWeb dataset. The script has two major parts: first, it performs the main processing for each dump; then it applies MinHash deduplication and PII formatting to the processed output.
+
+### 44.4.1 Main Processing Pipeline
+
+The main processing pipeline can be abstracted in the following order. Class names come from the DataTrove FineWeb example script; explanations are organized by this chapter.
+
+*Table 44-3 Key Modules in the FineWeb Main Processing Pipeline*
+
+| Order | DataTrove Module | Input | Output | Role |
+| ---: | --- | --- | --- | --- |
+| 1 | `WarcReader` | Common Crawl WARC segments | Raw HTML document stream | Reads Web snapshots from `s3://commoncrawl/crawl-data/.../warc/` |
+| 2 | `URLFilter` | URL and raw document | Retained or removed documents | Removes sources matching malicious, NSFW, or block-list patterns |
+| 3 | `Trafilatura` | Raw HTML | Extracted main text | Reduces menu, footer, and page-template noise |
+| 4 | `LanguageFilter` | Text | English document stream and non-English exclusion logs | Retains documents whose English score reaches the threshold |
+| 5 | `GopherRepetitionFilter` | English text | Repetition-pattern filtering result | Removes repeated n-grams and abnormally repetitive content |
+| 6 | `GopherQualityFilter` | Text statistics | Quality-filtering result | Applies MassiveText/Gopher-style quality rules |
+| 7 | `C4QualityFilter` | Text statistics | C4-rule filtering result | Applies the subset of C4 rules adopted by FineWeb |
+| 8 | `FineWebQualityFilter` | Text statistics | Custom-filtering result | Removes list-like, repeated-line, and abnormal-newline documents |
+| 9 | `JsonlWriter` | Retained documents | JSONL shards | Writes documents entering the deduplication stage |
+
+Sources: imported modules and main-processing pipeline in DataTrove `examples/fineweb.py`; FineWeb dataset card data-processing steps.
+
+The code structure of the main processing stage can be summarized as:
+
+```python
+pipeline = [
+    WarcReader(common_crawl_warc_path),
+    URLFilter(...),
+    Trafilatura(favour_precision=True),
+    LanguageFilter(...),
+    GopherRepetitionFilter(...),
+    GopherQualityFilter(...),
+    C4QualityFilter(...),
+    FineWebQualityFilter(...),
+    JsonlWriter(base_processing_output)
+]
+```
+
+This is conceptual pseudocode used to explain the module order in the FineWeb example script. Real parameters, log directories, S3 paths, task counts, and Slurm resource configurations should follow the DataTrove repository script.
+
+### 44.4.2 Deduplication and Privacy-processing Pipeline
+
+FineWeb uses MinHash for approximate deduplication. The goal of MinHash is to estimate the Jaccard similarity between two documents. If documents $A$ and $B$ are represented as sets of 5-grams, their similarity is:
+
+$$
+J(A,B)=\frac{|G_5(A)\cap G_5(B)|}{|G_5(A)\cup G_5(B)|}
+$$
+
+MinHash approximates this similarity with multiple hash functions. The FineWeb paper states that its deduplication parameters are 5-grams and 112 hash functions, split into 14 buckets with 8 hashes per bucket; if the 8 MinHash values in any bucket match, the pair is considered a duplicate candidate. The `MinhashConfig` in the DataTrove example script also corresponds to `n_grams=5`, `num_buckets=14`, and `hashes_per_bucket=8`.
+
+```mermaid
+flowchart TD
+  A["Main-processing output JSONL"] --> B["MinhashDedupSignature<br>Compute 5-gram MinHash signatures"]
+  B --> C["MinhashDedupBuckets<br>Group duplicate candidates by bucket"]
+  C --> D["MinhashDedupCluster<br>Generate remove_ids"]
+  D --> E["MinhashDedupFilter<br>Remove duplicate documents"]
+  E --> F["TokensCounter<br>Count tokens before and after deduplication"]
+  F --> G["PIIFormatter<br>Anonymize emails and public IPs"]
+  G --> H["deduped_output<br>Pre-release data shards"]
+```
+
+*Figure 44-1 FineWeb MinHash deduplication and PII-processing flow. Source: original illustration based on Hugging Face DataTrove `examples/fineweb.py` and the FineWeb dataset card.*
+
+### 44.4.3 FineWeb's Per-crawl Deduplication Judgment
+
+Intuitively, global deduplication seems more thorough: put all 96 crawls together and remove all near-duplicate documents. FineWeb's ablation experiments, however, produce the opposite signal. The paper describes a key phenomenon: when global deduplication is performed from the newest crawls toward older crawls, older crawls are heavily removed; in one older snapshot, the retained 10% of the data is actually worse than the removed 90%, containing more advertisements, keyword lists, and abnormally formatted text. FineWeb ultimately chooses to run MinHash deduplication independently for each crawl.
+
+This result matters for engineering practice. Deduplication is not mathematically better simply because it is more exhaustive; what matters is how it changes the data distribution. Global deduplication can alter the time distribution, site coverage, and duplicate-cluster structure across old and new crawls in complex ways. If one looks only at "how much duplication was removed," valuable samples may be removed while low-quality long-tail samples remain.
+
+```mermaid
+flowchart LR
+  A["Candidate strategy"] --> B["Fixed token sample"]
+  B --> C["Train isomorphic ablation models"]
+  C --> D["Evaluate fixed tasks with lighteval"]
+  D --> E{"Does aggregate score improve?"}
+  E -->|Improves| F["Keep strategy and freeze parameters"]
+  E -->|Does not improve| G["Rollback or reset thresholds"]
+  G --> A
+```
+
+*Figure 44-2 FineWeb data-processing-choice ablation loop. Source: original illustration based on FineWeb paper Section 3.1.*
+
+## 44.5 Evaluating FineWeb Data-processing Choices
+
+FineWeb's evaluation method differs from a typical dataset introduction. It treats data-processing steps as experimental variables and trains ablation models to compare different data versions. The paper states that ablation models keep model parameters, architecture hyperparameters, training token count, and training steps consistent. To reduce random-sampling effects, each data version is used to train two models with different random subsets and different initialization seeds, and their average scores are compared.
+
+### 44.5.1 Fixed Variables
+
+FineWeb's evaluation protocol can be summarized in Table 44-4.
+
+*Table 44-4 FineWeb Data-ablation Evaluation Protocol*
+
+| Control Item | FineWeb Paper Practice | Data-engineering Meaning |
+| --- | --- | --- |
+| Model scale | Ablation model has 1.82B parameters and Llama architecture | Prevents model-scale changes from hiding data differences |
+| Tokenizer | GPT-2 tokenizer | Fixes token-statistics convention |
+| Training budget | Filtering ablations use about 28B tokens; some deduplication and cumulative-improvement experiments use 350B tokens | Separates quick screening from high-cost validation |
+| Repeated experiments | Two models per data version, with different random subsets and initialization seeds | Reduces sampling and initialization noise |
+| Training framework | Nanotron | Fixes training implementation |
+| Evaluation framework | lighteval | Fixes evaluation implementation |
+| Evaluation tasks | CommonSense QA, HellaSwag, OpenBook QA, PIQA, SIQA, WinoGrande, ARC, MMLU | Uses multitask signals to evaluate data-processing effects |
+
+Source: FineWeb paper Section 3.1, Experimental setup.
+
+If data version $v$ is trained twice, producing models $M_{v,1}$ and $M_{v,2}$, and each model is evaluated on $k$ tasks, the version score can be written as:
+
+$$
+\bar{S}_v=\frac{1}{2k}\sum_{r=1}^{2}\sum_{i=1}^{k}s(M_{v,r},b_i)
+$$
+
+This formula is also an engineering expression of the FineWeb evaluation protocol. It emphasizes that the evaluation object is not a single sample, but a data version generated by a processing strategy.
+
+Filters cannot be decided once based only on rule intuition. FineWeb's filter selection can be divided into three steps.
+
+First, build baseline filtering. After extracting text from WARC, FineWeb first applies URL block lists, English language identification, and Gopher/MassiveText-style quality filtering. The paper reports that after applying these baseline steps to WARC-extracted text from 96 snapshots, the result is about 36T GPT-2 tokens.
+
+Second, compare existing rules. When studying C4 rules, FineWeb finds that the terminal-punctuation rule alone brings a clear improvement but removes about 30% of tokens. FineWeb ultimately adopts a subset of C4 rules excluding terminal punctuation, because it removes less data and yields a more suitable training benefit.
+
+Third, design custom filters. FineWeb collects more than 50 document-level and cross-document statistical indicators, compares distributions between "higher-quality" and "lower-quality" data, chooses thresholds that distinguish the two, and validates them with 28B-token ablation runs. The adopted custom filters focus on three issues: low ratio of lines ending in punctuation, high ratio of repeated-line characters, and abnormal ratio of short lines.
+
+### 44.5.3 Common Failures and Repair Actions
+
+FineWeb's experience can be converted into an error-attribution table for Web pre-training corpora. This is not an official FineWeb table, but an engineering retrospective organized by this chapter from the FineWeb paper and dataset card.
+
+*Table 44-5 Common Failures and Repair Actions for FineWeb-like Web Corpora*
+
+| Error Type | Symptom | Possible Root Cause | Data-engineering Repair Action |
+| --- | --- | --- | --- |
+| Page-template residue | Model repeats menus, footers, or cookie text | Direct WET usage or poor main-text extraction | Return to WARC, re-extract with Trafilatura or similar tools, and sample-check template residue |
+| Non-English mixing | Multilingual garbling and mixed scripts appear during English-model training | Loose language threshold or untreated mixed-language paragraphs | Preserve `language_score`, sample by score buckets, and apply paragraph-level filtering if needed |
+| Oversized duplicate clusters | Loss appears stable but downstream tasks do not improve | Template sites, mirrored sites, cross-month repetition | Use MinHash deduplication and record duplicate clusters and deduplication scope |
+| Global deduplication hurts distribution | Model does not improve after large deletion of older crawl content | Global deduplication changes time and quality distributions | Compare per-crawl and global deduplication under a fixed training budget |
+| Overly strict filters | Token scale drops and long-tail knowledge is removed | A single rule removes too many tokens | Record token-removal rate per filter and decide thresholds through ablation |
+| Residual privacy samples | Emails, public IPs, or other identifiable information enter release data | Missing PII processing or false negatives | Use `PIIFormatter` or similar rules and record replacement strategy and boundaries |
+
+## 44.6 Usage Boundaries of Public Web Corpora
+
+FineWeb is a strong public case for open Web pre-training corpus engineering, but it should not be understood simply as "all Web text that can be used directly for commercial training." Public datasets, open code, and the ODC-By license reduce the barrier to research reproduction, but they do not automatically remove copyright, privacy, safety, or removal responsibilities in the user's jurisdiction, business scenario, or downstream model release.
+
+FineWeb is suitable for English foundation-model pre-training, Web-data filtering research, deduplication-strategy ablations, debugging DataTrove-like large-scale text-processing pipelines, and teaching version governance for pre-training corpora. It is especially suitable for answering questions such as "does a particular data-processing step make the model better," because the public materials provide code, dataset cards, paper ablations, and evaluation protocols.
+
+FineWeb is not suitable for answering all training-data questions across all languages, domains, and compliance environments. It mainly consists of English Web content from Common Crawl; it is not equivalent to Chinese corpora, professionally licensed corpora, medical/legal/financial corpora, or SFT/preference data for conversational assistants.
+
+When enterprises reproduce the FineWeb idea, the most valuable transferable pieces are not fixed thresholds, but four engineering objects.
+
+First, processing code should be versioned. `code_commit`, filter parameters, tokenizer, sampling seed, and dump list should all enter the manifest. Second, filters should have exclusion logs. Ideally, every deleted sample can explain which rule deleted it. Third, deduplication should preserve scope and parameters. Per-dump, per-domain, and global deduplication have different effects; it is not enough to record only "deduplicated." Fourth, evaluation must fix variables. If model architecture, training tokens, training steps, evaluation sets, and random seeds are not fixed, conclusions about data processing are not comparable.
+
+FineWeb should not be used as an unreviewed commercial training corpus. Commercial models still require license, robots/terms, data-removal, privacy, and sensitive-content reviews. FineWeb should also not be treated as the only standard for a "high-quality English corpus." Its quality definition comes from fixed ablation models and a set of academic benchmarks, which do not necessarily cover helpfulness, safety, factual freshness, or instruction-following needs in real products.
+
+For Chinese or multilingual training, one cannot directly copy FineWeb's English FastText threshold, English tokenizer statistics, or assumptions about English page formats. Migration requires recalibrating language identification, simplified/traditional Chinese handling, site templates, domain distributions, low-quality-page rules, and evaluation tasks.
+
+## Chapter Summary
+
+FineWeb clarifies an often underestimated issue: a Web pre-training corpus is not the result of downloading Common Crawl; it is a data asset jointly formed by code, filters, deduplication strategy, evaluation protocol, and release documentation. This chapter's core conclusions are threefold.
+
+First, Web main-text extraction is a model-capability variable. FineWeb re-extracts text from WARC with Trafilatura precisely because WET text can retain too much template and menu noise. Second, deduplication strategy must be validated through training results. FineWeb's experiments show that global MinHash deduplication is not necessarily better than independent per-crawl deduplication, and removing more duplicates does not equal obtaining better training data. Third, filter selection should enter a fixed evaluation protocol. Through isomorphic ablation models, fixed token budgets, lighteval evaluation, and repeated random seeds, FineWeb turns data-processing choices into reviewable engineering experiments.
+
+For readers of this book, what is most worth learning from FineWeb is not copying a particular token scale, but turning pre-training corpus engineering into a traceable, reproducible, evaluable, and auditable system.
+
+## References
+
+- Penedo, G., Kydlíček, H., Allal, L. B., Lozhkov, A., Mitchell, M., Raffel, C., von Werra, L., & Wolf, T. (2024). The FineWeb Datasets: Decanting the Web for the Finest Text Data at Scale. NeurIPS 2024 Datasets and Benchmarks Track. https://arxiv.org/abs/2406.17557
+- Hugging Face. (2026). HuggingFaceFW/fineweb Dataset Card. https://huggingface.co/datasets/HuggingFaceFW/fineweb
+- Hugging Face. (2026). DataTrove FineWeb Processing Script. https://github.com/huggingface/datatrove/blob/main/examples/fineweb.py
+- Penedo, G., Kydlíček, H., Cappelli, A., Sasko, M., & Wolf, T. (2024). DataTrove large scale data processing. https://github.com/huggingface/datatrove
+- Luccioni, S., & Viviano, J. (2021). What's in the Box? A Preliminary Analysis of Undesirable Content in the Common Crawl Corpus. https://arxiv.org/abs/2105.02732

--- a/docs/en/part12/ch45_dolma_olmo_transparent_corpus.md
+++ b/docs/en/part12/ch45_dolma_olmo_transparent_corpus.md
@@ -1,0 +1,298 @@
+# Chapter 45: Dolma Pre-training Corpus Transparent Ledger
+
+## Abstract
+
+Most open model releases provide weights, inference code, and some evaluation results, but training data is often reduced to vague source descriptions. This is insufficient for continued pre-training, bias analysis, evaluation-contamination checks, and license audits. When a model exhibits a problem, the team can hardly answer which sources it saw, how those sources were filtered, what the sampling proportions were, whether a benchmark leaked into the training corpus, or which shard should be located when a user requests removal of personal data.
+
+Dolma is a three-trillion-token-scale English pre-training corpus released by the Allen Institute for AI to support open language-model research and OLMo training. Its value is not only scale; it turns pre-training data into an auditable engineering record: versions, sources, source-level statistics, sample proportions, the ODC-BY license, original-source terms, a personal-data removal entry point, and the Dolma Toolkit processing flow are all documented publicly. Around this ledger, the chapter starts from the data gap in open-model research, then reviews Dolma versions and source statistics, then follows the source ledger, individual document records, and training manifest to decompose the sample structure. Finally, it discusses how Dolma Toolkit turns tag, dedup, mix, and tokenize into auditable actions, and where transparent corpora are bounded in quality control, removal, and enterprise migration.
+
+## Keywords
+
+Dolma; transparent pre-training corpus; OLMo; source mix; token accounting; source card; manifest; Dolma Toolkit; ODC-BY; data audit
+
+## 45.0 Learning Objectives
+
+After completing this chapter, readers should be able to:
+
+- Explain why open weights cannot substitute for training-data transparency.
+- Read Dolma's versions, source statistics, sampling proportions, and ODC-BY usage boundaries.
+- Distinguish the roles of document records, source cards, and training manifests in audits.
+- Use token-accounting formulas to describe the relationship among raw tokens, filtered tokens, sample proportions, and seen tokens.
+- Understand the evidence chain of transparent corpora through the four Dolma Toolkit actions: tag, dedup, mix, and tokenize.
+- Design source ledgers, removal ledgers, contamination checks, and version-freezing mechanisms for internal enterprise pre-training corpora.
+
+## 45.1 Problem Scenario: Open Weights Still Cannot Explain the Model
+
+Two teams obtain the same 7B open-model weights. The first team wants to continue pre-training the model to improve code and scientific-question-answering capabilities. The second team wants to analyze why the model gives outdated answers on several factual questions. The weights, inference code, and part of the evaluation scripts are downloadable, but they quickly encounter the same problem: no one can answer what data the model actually saw.
+
+The continued-pretraining team needs to know how much code, papers, encyclopedic content, Web text, and social media were present in the original model corpus, so that it does not repeatedly oversample the same data types. The bias-analysis team needs to know whether certain Web pages, papers, forum discussions, or benchmark solutions entered training, so it can judge whether a problem comes from knowledge gaps, sampling weights, contamination, or model training itself. Without training corpora and processing records, every explanation remains guesswork.
+
+Dolma is designed to solve exactly this problem. It turns an English pre-training corpus from an invisible data recipe into a set of downloadable, measurable, processable, removable, and auditable sources. OLMo is not a parallel protagonist in this chapter, but a downstream example of Dolma being consumed by a transparent training chain. It reminds us that open model research should not only open weights; it should open training data, processing tools, and evaluation code as far as possible.
+
+### 45.1.1 Open-model Research Needs Data Evidence
+
+"Open" has different levels. Releasing only weights allows users to run a model, but does not allow researchers to explain it. Releasing training code allows users to reproduce the training framework, but still does not explain what the model actually saw. Data transparency that supports scientific research must answer at least six classes of questions.
+
+- Source: Does each document come from Common Crawl, code repositories, papers, books, encyclopedias, or social platforms?
+- Version: What were the source acquisition time, processing-script version, and filtering rules?
+- Scale: Are raw tokens, filtered tokens, sampled tokens, and seen tokens consistent?
+- Contamination: Did evaluation sets, solutions, or customer test sets overlap with the training corpus?
+- License: How do the dataset release license and original-source terms jointly constrain users?
+- Removal: If a user requests removal of personal data, can the corresponding document be located and handled?
+
+The Dolma dataset card directly reflects this design orientation: it lists versions, summary statistics, download methods, license information, and a personal-data removal entry point. The Dolma GitHub repository further provides data and tools, so transparency is not limited to paper descriptions.
+
+For corpora like Dolma, the core object of transparency is a ledger; a single `text` field is not the only object. More important are three ledgers formed around `text`.
+
+The first is the source ledger, recording where each data type comes from, how large it is, what cutoff date it uses, and how it was processed. The second is the processing ledger, recording how taggers, filters, deduplication strategies, mixers, and tokenizers changed raw documents. The third is the training ledger, recording which sources a training run actually sampled, what the sampling proportions were, and how seen tokens were distributed across training steps.
+
+If these three ledgers are disconnected, transparency degrades into "downloadability." The data can be downloaded, but cannot explain the model; the model can be trained, but cannot be audited; versions can be updated, but cannot be compared.
+
+## 45.2 Dataset Overview: Versions, Scale, and Source Structure
+
+Dolma is not a single static file, but a corpus asset with version evolution. The Hugging Face dataset card lists versions such as `v1`, `v1_5`, `v1_5-sample`, `v1_6`, `v1_6-sample`, and `v1_7`. Among them, `v1_7` is used to train OLMo 7B-v1.7 and introduces new sources, more quality filtering, and fuzzy deduplication.
+
+*Table 45-1 Public Dolma Versions and Uses*
+
+| Version | Release Date | Compressed Size | Dataset-card Description | Engineering Use |
+| --- | --- | ---: | --- | --- |
+| `v1` | 2023-08-18 | 6.0 TB | First Dolma release | Trace the earliest public corpus form |
+| `v1_5` | 2023-10-31 | 6.4 TB | Used to train OLMo-1B, about 3T tokens | Review early OLMo training corpus |
+| `v1_5-sample` | 2023-10-31 | 2.9 TB | Sample of about 1.9T tokens, used for OLMo-7B | Track training samples below full scale |
+| `v1_6` | 2024-01-31 | 5.4 TB | Adds partial deduplication and repeated n-gram filtering on top of v1.5 | Study filtering and deduplication evolution |
+| `v1_6-sample` | 2024-01-31 | 16.4 GB | Exploratory sample of about 10B tokens | Quick debugging and data browsing |
+| `v1_7` | 2024-04-15 | 4.5 TB | Used to train OLMo 7B-v1.7, with new sources, more quality filtering, and fuzzy deduplication | Current default version and transparent-training reference |
+
+Source: Versions section of the Hugging Face `allenai/dolma` dataset card.
+
+### 45.2.1 v1.6 Source Structure
+
+Dolma covers Web, code, papers, social media, books, and encyclopedic sources. To avoid mixing versions, Table 45-2 uses the coarse-grained statistics from the dataset card's v1.6 summary statistics. The v1.7 sources are more fine-grained, adding Refined Web, StarCoder, arXiv, StackExchange, Flan, OpenWebMath, Algebraic Stack, MegaWika, and other sources. Subsequent writing or experiments should explicitly state which version is used.
+
+*Table 45-2 Dolma v1.6 Source Statistics*
+
+| Source | Document Type | UTF-8 Bytes | Documents | Unicode Words | Llama Tokens |
+| --- | --- | ---: | ---: | ---: | ---: |
+| Common Crawl | web pages | 9,022 GB | 3,370M | 1,775B | 2,281B |
+| The Stack | code | 1,043 GB | 210M | 260B | 411B |
+| C4 | web pages | 790 GB | 364M | 153B | 198B |
+| Reddit | social media | 339 GB | 377M | 72B | 89B |
+| PeS2o | STEM papers | 268 GB | 38.8M | 50B | 70B |
+| Project Gutenberg | books | 20.4 GB | 0.056M | 4.0B | 6.0B |
+| Wikipedia and Wikibooks | encyclopedic | 16.2 GB | 6.2M | 3.7B | 4.3B |
+| Total | mixed | 11,519 GB | 4,367M | 2,318B | 3,059B |
+
+Source: Hugging Face `allenai/dolma` dataset card, Summary Statistics v1.6. GB, M, and B follow the dataset-card convention.
+
+Table 45-2 should not be read only as a scale display. It reveals three engineering facts.
+
+First, Dolma is a source mix, not a single Web dump. Common Crawl accounts for a large share, but code, papers, social media, books, and encyclopedic content all enter the corpus in different forms. Changes in model capability cannot be vaguely attributed to "more Web data."
+
+Second, different statistical conventions serve different questions. UTF-8 bytes help estimate storage and processing cost, document count helps observe sample granularity, while Unicode words and Llama tokens are closer to the training budget. Mixing these conventions distorts discussions of data scale.
+
+Third, versions cannot be directly compared without care. v1.6 and v1.7 differ in source decomposition, filtering rules, and sample proportions. If a model is trained with v1.7, one cannot explain its training behavior using only the v1.6 coarse table.
+
+## 45.3 Decomposing a Transparent Chain Through the Source Ledger
+
+This section does not begin from an individual text, but from Dolma's source ledger to decompose the chain of a transparent pre-training corpus. The "sample" here is not an image or a question, but an evidence path from source to document and then to the training manifest.
+
+### 45.3.1 From Source to Document
+
+Dolma's task is not to annotate supervised labels for each text, but to make records consumed by training reconstructable. Let the source set be $S=\{s_1,\ldots,s_m\}$. Each source is processed by a function $P_s$ into a document set $D_s$:
+
+$$
+D_s=P_s(R_s, C_s)
+$$
+
+Here, $R_s$ is the raw source, and $C_s$ is the processing configuration for that source, including taggers, filters, deduplication strategy, sampling proportion, and tokenizer. The final training corpus is a mixture of multiple sources:
+
+$$
+D=\bigcup_{s \in S} Sample(D_s, r_s)
+$$
+
+Dolma's transparency lies in recording $S$, $R_s$, $C_s$, $r_s$, and version information as publicly as possible. Model training is no longer just "used three trillion tokens"; it can be traced to which sources contributed how much, how they were processed, and how they were sampled.
+
+### 45.3.2 Token Accounting Should Track Actual Training Consumption
+
+The easiest part of a multi-source corpus to misread is token scale. A source with many raw tokens does not necessarily contribute the same proportion during training; filtering, deduplication, sample proportion, and multiple epochs all change the final seen tokens.
+
+The actual contribution of a source $s$ during training can be written as:
+
+$$
+T^{seen}_s = T^{filtered}_s \times r_s \times e_s
+$$
+
+where $T^{filtered}_s$ is the number of filtered tokens, $r_s$ is the sampling proportion, and $e_s$ is the epoch count or equivalent sampling count during training. The proportion of that source in the training mix is:
+
+$$
+p_s=\frac{T^{seen}_s}{\sum_j T^{seen}_j}
+$$
+
+The Dolma v1.7 dataset card lists both source token counts and sample proportions precisely so that users can distinguish "what is in the dataset" from "how much the model actually saw."
+
+### 45.3.3 Three Ways to Read a Document
+
+Transparent corpora do not end with packaging and uploading `text`. At least three layers of records are needed: an individual document record, a source card, and a training-version manifest. The document record supports training and location; the source card explains data origin and processing rules; the training manifest reproduces the data actually consumed by a model run.
+
+*Table 45-3 Dolma-like Transparent Corpus Record Schema*
+
+| Layer | Typical Fields | Source or Generation Method | Engineering Use |
+| --- | --- | --- | --- |
+| Document level | `id`, `source`, `text`, `text_hash` | Data reader and hash computation | Locate samples, deduplicate, read during training |
+| Document level | `created_at`, `url_or_origin`, `license_hint` | Original source metadata | License review and time tracking |
+| Document level | `language_tag`, `toxicity_tag`, `perplexity_score` | Dolma Toolkit taggers or custom taggers | Quality filtering and risk bucketing |
+| Source level | `source_name`, `source_version`, `raw_size`, `filtered_size` | Source card and statistics scripts | Explain data composition |
+| Source level | `dedup_policy`, `filter_config`, `sample_proportion` | Dolma mixer and processing configs | Reproduce source mix |
+| Training level | `dolma_version`, `tokenizer`, `sample_seed`, `seen_tokens` | Training manifest | Reproduce experiments and explain metric changes |
+| Governance level | `removal_status`, `known_limitations`, `release_constraints` | Dataset card and governance records | Handle removal, bias, and usage boundaries |
+
+These fields are an engineering schema organized by the author from the Dolma dataset card, Dolma Toolkit documentation, and transparent-training audit needs. They do not imply that Dolma officially publishes each field exactly as listed.
+
+The following is an abstract Dolma-like document record showing how a transparent corpus connects samples, sources, and training versions.
+
+```json
+{
+  "id": "dolma-v1_7/common-crawl/doc-000001",
+  "source": "Dolma's CC",
+  "source_version": "v1_7",
+  "text": "<document text>",
+  "text_hash": "sha256:...",
+  "tags": {
+    "language": "en",
+    "toxicity_bucket": "low",
+    "perplexity_bucket": "normal"
+  },
+  "processing": {
+    "tagger_config": "dolma-toolkit-config-x",
+    "dedup_policy": "fuzzy_dedup",
+    "sample_proportion": 0.5
+  },
+  "training_manifest": {
+    "tokenizer": "OLMo tokenizer version",
+    "dolma_version": "v1_7",
+    "included_in_run": true
+  }
+}
+```
+
+This record cannot be read at only one layer. In Dolma, the document layer, source layer, and training layer must point back to one another. If a document has a `source` but no source card, it can locate a sample but cannot explain the origin. If a source card has statistics but no training manifest, it can explain what is in the dataset but not what the model actually saw. If a manifest has sampling proportions but no document hash, removal and contamination checks break.
+
+## 45.4 Dolma Toolkit Makes the Evidence Chain Executable
+
+The Dolma GitHub repository states that Dolma is both a dataset and a toolkit. Dolma Toolkit supports single-machine, cluster, and cloud environments. It includes language detection, toxicity detection, perplexity scoring, and common filtering recipes such as Gopher, C4, and OpenWebText; its deduplication component uses a Rust Bloom filter for acceleration.
+
+### 45.4.1 Four Actions Correspond to Four Kinds of Evidence
+
+Dolma Toolkit documentation summarizes data organization as four actions: tag, dedup, mix, and tokenize. They are not isolated scripts, but evidence-chain generators: tag records document attributes, dedup records what is retained and removed, mix records sampling proportions, and tokenize records the token convention that enters training.
+
+*Table 45-4 Dolma Toolkit Processing Actions and Evidence Outputs*
+
+| Order | Action | Official Documentation Description | Evidence Output | Main Risk |
+| ---: | --- | --- | --- | --- |
+| 1 | Taggers | Assign language, toxicity, perplexity, and other attribute tags to document spans | Document quality labels and risk labels | Tagger-version changes alter filtering results |
+| 2 | Deduplication | Deduplicate documents by content or metadata | Deduplication strategy, retention priority, deletion records | Cross-source deduplication changes source mix |
+| 3 | Mixer | Remove, filter, or mix documents based on attribute values | Sample proportion, source mix, data version | Opaque sample proportions cause token-accounting errors |
+| 4 | Tokenization | Use Hugging Face-compatible tokenizers | Token counts, tokenizer version, training stream | Tokenizer changes alter token counts and training budget |
+
+Source: Dolma Toolkit documentation README.
+
+```mermaid
+flowchart LR
+  A["Source card<br>origin / license / cutoff"] --> B["Taggers<br>quality and risk evidence"]
+  B --> C["Deduplication<br>keep / remove evidence"]
+  C --> D["Mixer<br>sample proportion"]
+  D --> E["Tokenization<br>seen-token accounting"]
+  E --> F["Training manifest<br>run-level evidence"]
+```
+
+*Figure 45-1 Dolma transparent-corpus evidence chain. Source: original illustration based on AllenAI Dolma Toolkit documentation.*
+
+The boundary between toolchains and manual audits matters. A toolchain can stably generate statistics, tags, hashes, and manifests, but it cannot replace all audits. License boundaries, PII removal, evaluation contamination, and source representativeness still require human rules, sample review, or dedicated detection tasks.
+
+This is also the difference between a Dolma-like transparent corpus and an ordinary "collection of cleaning scripts." Ordinary scripts only answer "what did I delete"; a transparent toolchain must also answer "why was it deleted, how did the post-deletion distribution change, did training actually benefit, and can it be removed later." If a processing action cannot leave interpretable evidence, it is hard for it to support transparent training.
+
+## 45.5 Evaluation Shifts from Highest Score to Attribution
+
+The evaluation focus of transparent corpora is not the "highest score," but whether score changes can be explained. Dolma-like source-level corpora let model evaluation move beyond leaderboards and trace training logs back to sources, versions, and sampling proportions.
+
+### 45.5.1 Source Ablation Locates Capability Sources
+
+To judge whether a source affects model capability, one can run source ablation. Let full training produce model $M_{all}$, and training with source $s$ removed produce model $M_{-s}$. The average difference over task set $B$ is:
+
+$$
+\Delta_s=\frac{1}{|B|}\sum_{b \in B} \left[score(M_{all}, b)-score(M_{-s}, b)\right]
+$$
+
+When $\Delta_s$ changes clearly on code tasks, scientific QA, or long-context tasks, the data team can trace capability changes back to source mix instead of vaguely attributing them to "model parameters."
+
+```mermaid
+flowchart TD
+  A["Source statistics<br>tokens / documents / cutoff"] --> B["Sample proportion"]
+  B --> C["Seen tokens by source"]
+  C --> D["Training run"]
+  D --> E["Checkpoint evaluation"]
+  E --> F["Source-level diagnosis"]
+  F --> B
+```
+
+*Figure 45-2 Dolma source mix and training-diagnosis loop. Source: original illustration based on the Dolma dataset card and OLMo training use.*
+
+### 45.5.2 Diagnosis Checklist
+
+*Table 45-5 Dolma-like Transparent Corpus Evaluation and Diagnosis Table*
+
+| Evaluation Question | Required Records | Metric or Evidence | Possible Action |
+| --- | --- | --- | --- |
+| Which source drives a capability | Source mix, sample proportion, seen tokens | Source ablation, task-score difference $\Delta_s$ | Adjust source weight or add data |
+| Whether an evaluation set is contaminated | Document hash, n-gram index, eval-set hash | Overlap rate, contamination span | Remove contaminated samples and freeze a new version |
+| Training loss fluctuates abnormally | Batch source records, tokenizer version | Source-specific loss, token distribution | Inspect sampler and source shards |
+| Social-media risk increases | Toxicity tag, PII tag, source card | Risk-tag rate, manual sample review | Tighten filtering or reduce sampling proportion |
+| Versions are incomparable | `dolma_version`, `filter_config`, `dedup_policy` | Manifest diff | Freeze version or rerun controlled experiments |
+
+### 45.5.3 Common Failure Modes
+
+*Table 45-6 Common Failures and Repair Actions for Dolma-like Transparent Corpora*
+
+| Failure Mode | Symptom | Possible Root Cause | Governance Action |
+| --- | --- | --- | --- |
+| Source-mix drift | A task category suddenly regresses in a new version | Sample proportion or filtering rules changed | Compare manifest diff, roll back, or resample by strata |
+| Inconsistent token accounting | Reported scale does not match training seen tokens | Raw, filtered, and sampled tokens are mixed | Report raw, filtered, sampled, and seen tokens together |
+| Cross-source duplication | Paper abstracts, encyclopedia mirrors, or code fragments repeat | Deduplication only within source | Add cross-source deduplication and record retention priority |
+| Evaluation contamination | Benchmark scores become abnormally high | Web or forum data contains questions and solutions | Build eval hash/n-gram decontamination index |
+| Removal cannot be located | PII removal request cannot be handled | Missing source/id/hash mapping | Build removal ledger and shard reverse index |
+| Ambiguous license boundary | ODC-BY is mistaken for authorization from original sources | Original source terms are ignored | Preserve original terms and restrictions in source cards |
+
+These failure modes show that transparent-corpus quality is not only about whether text is clean. A transparent training sample must pass three kinds of checks simultaneously: whether the source is explainable, whether the processing actions are reproducible, and whether training consumption is traceable. Missing any one of these checks can turn data into a corpus that is public but not auditable.
+
+## 45.6 Reuse Boundaries of Transparent Corpora
+
+Dolma is suitable for open language-model pre-training research, source-mix experiments, transparent data-governance teaching, training-data audit method validation, and internal enterprise manifest design. It is especially suitable for research questions such as "how does training data affect model capabilities and limitations," because it opens data, dataset cards, and processing tools together.
+
+Dolma should not be understood as meaning that all sources are unconditionally usable for commercial purposes. The Hugging Face dataset card states that Dolma is released under ODC-BY, while users are still bound by the licenses and terms of use of the original data sources. In other words, Dolma's release license does not automatically erase the boundaries of Common Crawl, Reddit, code, papers, books, and other original sources.
+
+Enterprises usually cannot publish training data, but they can transfer Dolma's transparency practices. A minimum viable version includes:
+
+- Build a source card for each source, recording origin, version, license, acquisition time, filtering rules, and limitations.
+- Freeze a manifest for each training version, recording source mix, sample proportion, tokenizer, `filter_config`, `dedup_policy`, and `sample_seed`.
+- Build validation splits for major sources to support source-specific loss and source ablation.
+- Build decontamination indexes for evaluation sets, customer test sets, and online issue repositories.
+- Build a removal ledger so that URL, document id, or text hash can map to training shards.
+
+At the same time, Dolma is not suitable as a direct quality standard for Chinese, multilingual, or vertical-industry corpora. It is primarily an English pre-training corpus. Migration to Chinese, medical, legal, or financial scenarios requires redefining sources, licenses, filters, and evaluation tasks. Dolma should also not be used to prove that open corpora are inherently safe. The meaning of transparency is that defects are visible, locatable, and repairable, not that defects do not exist.
+
+## Chapter Summary
+
+Dolma moves pre-training corpora from invisible data recipes toward auditable data assets. This chapter's core conclusions are threefold.
+
+First, the basic unit of a transparent pre-training corpus is not a single `text` field, but a document record that connects source, processing configuration, sampling proportion, and training manifest. Second, source mix must be explained through token accounting rather than by reporting only raw scale. Third, the four Dolma Toolkit actions - tag, dedup, mix, and tokenize - provide a clear template for enterprises building reproducible training corpora internally.
+
+For readers of this book, what is most transferable from Dolma is not a particular source or the three-trillion-token scale, but the way it leaves evidence for training data. Only when sources, processing actions, sampling proportions, training manifests, and governance records form a connected chain does a pre-training corpus have a foundation for continued research, error attribution, and long-term maintenance.
+
+## References
+
+- Soldaini, L., Kinney, R., Bhagia, A., Schwenk, D., Atkinson, D., Authur, R., et al. (2024). Dolma: an Open Corpus of Three Trillion Tokens for Language Model Pretraining Research. ACL 2024. https://arxiv.org/abs/2402.00159
+- Allen Institute for AI. (2023). Ai2 Dolma: 3 trillion token open corpus for language model pretraining. https://allenai.org/blog/dolma-3-trillion-tokens-open-llm-corpus-9a0ff4b8da64
+- AllenAI. (2026). allenai/dolma Dataset Card. https://huggingface.co/datasets/allenai/dolma
+- AllenAI. (2026). Dolma Dataset and Toolkit Repository. https://github.com/allenai/dolma
+- AllenAI. (2026). Dolma Toolkit Documentation. https://github.com/allenai/dolma/blob/main/docs/README.md
+- Groeneveld, D., Beltagy, I., Walsh, P., Bhagia, A., Kinney, R., Tafjord, O., et al. (2024). OLMo: Accelerating the Science of Language Models. https://arxiv.org/abs/2402.00838

--- a/docs/en/part12/ch46_laion_datacomp_image_text.md
+++ b/docs/en/part12/ch46_laion_datacomp_image_text.md
@@ -1,0 +1,282 @@
+# Chapter 46: LAION-5B Image-Text Candidate Pool and Filtering Channels
+
+## Abstract
+
+The largest difference between image-text foundation corpora and pure-text corpora is not simply the addition of image files, but that each sample is split into multiple channels that must all hold at the same time. The text channel must explain how the image is described; the visual channel must explain whether the image can be downloaded and whether its size and content are usable; the alignment channel must explain whether image and text are related; and the risk channel must explain whether there are watermark, NSFW, toxicity, privacy, or authorization risks. If any one channel fails, the image-text pair may be unsuitable for training.
+
+LAION-5B is a large-scale image-text candidate pool derived from Common Crawl. It parses IMG tags and alt text from Web WAT metadata, then uses language identification, image downloading, CLIP or multilingual CLIP similarity filtering, watermark and NSFW detection, nearest-neighbor indexing, and Parquet metadata release to organize open Web image-text pairs into a searchable, filterable, and reviewable data asset. This chapter decomposes LAION-5B into five channels - text, visual, alignment, risk, and release - and then discusses how candidate pools are filtered into training views, evaluation views, and governance views. DataComp is not the main dataset of this chapter; it serves as an evaluation-protocol reference showing how to compare different image-text filtering strategies under fixed models and fixed downstream evaluations.
+
+## Keywords
+
+LAION-5B; image-text pairs; Common Crawl; alt text; CLIP filtering; multi-channel schema; WebDataset; Parquet; DataComp; risk governance
+
+## 46.0 Learning Objectives
+
+After completing this chapter, readers should be able to:
+
+- Explain why Web image-text pairs must be checked through text, visual, alignment, risk, and release channels.
+- Understand the English, multilingual, and no-language subset structure of LAION-5B.
+- Design a traceable image-text sample schema covering URL, text, image dimensions, CLIP score, safety labels, and removal status.
+- Use CLIP similarity and threshold functions to describe image-text filtering gates.
+- Distinguish candidate-pool views, training views, evaluation views, and governance views.
+- Compare image-text filtering strategies using DataComp-style fixed training protocols.
+- Identify risks involving public URLs, copyright, faces, children, NSFW content, watermarks, and link decay.
+
+## 46.1 Opening Problem Scenario: Image-Text Pairs Need Channelized Filtering
+
+A multimodal team is preparing to train a vision-language model. It extracts billions of `<image_url, alt_text>` pairs from Web pages and then asks a download script to fetch images by URL. The first round of sampling quickly exposes problems: many URLs have already expired; many alt texts are filenames, advertising phrases, SEO keywords, or unrelated paragraphs; some images are too low-resolution, contain watermarks, include adult content, faces, children's photos, medical images, or copyright marks. More importantly, image and text appearing related does not mean the pair is suitable for training. A product image captioned "click to buy" contributes little to learning visual concepts; a personal photo paired with a name, address, or social account introduces privacy risk into the model.
+
+If such data is compressed into a free-text prompt, later problems become almost impossible to locate. If the model generates watermarks, the issue lies in the visual channel; if the model learns advertising templates, the issue lies in the text channel; if image-text retrieval is weak, the issue lies in the alignment channel; if faces, children, or copyright disputes appear after training, the issue lies in the risk and governance channels. The engineering lesson from LAION-5B is that it does not simply package Web images; it decomposes candidate image-text relationships into a set of filterable fields that downstream teams can recombine according to their task objectives.
+
+Ordinary image datasets usually center on image files and human labels, and sample boundaries are relatively stable. Image-text candidate pools differ. Images may expire or be replaced at their URLs; alt text may not be a caption; Web-page context may be only weakly related to the image; and safety labels may change with detector versions. A sample is not a static object, but a Web relationship that must be continuously verified.
+
+This relationship has at least three kinds of fragility. The first is temporal fragility: URLs expire, images update, and pages redirect. The second is semantic fragility: alt text may serve accessibility, SEO, or template display rather than image description. The third is governance fragility: a publicly accessible URL does not imply clear authorization, nor does it imply the absence of faces, children, medical content, trademarks, or watermark risk.
+
+### 46.1.2 CLIP Scores Solve Only Part of Image-Text Relevance
+
+LAION-5B's core filtering signal comes from cosine similarity between image and text embeddings. Let the image encoder be $f_I$, the text encoder be $f_T$, the image be $i$, and the text be $t$. The image-text similarity can be written as:
+
+$$
+\operatorname{sim}(i,t)=\frac{f_I(i)\cdot f_T(t)}{\|f_I(i)\|\|f_T(t)\|}
+$$
+
+Threshold filtering can be abstracted as:
+
+$$
+\operatorname{keep}(i,t)=\mathbb{1}[\operatorname{sim}(i,t)\ge \tau_{\ell}]
+$$
+
+where $\tau_{\ell}$ can be set by language or subset. This filtering improves image-text relevance, but it is not proof of factual correctness, safety, or authorization compliance. A high-CLIP-score image may still contain watermarks, faces, adult content, private information, or copyright risk; a low-CLIP-score sample may still be valuable for certain tasks such as charts, document pages, or medical images.
+
+## 46.2 Dataset Overview: Subset Scale and Public Form
+
+The LAION-5B paper reports 5.85B CLIP-filtered image-text pairs, including approximately 2.32B English pairs, 2.26B multilingual pairs, and 1.27B pairs with uncertain language. This split matters because language identification, CLIP models, filtering thresholds, and downstream tasks all affect sample value.
+
+*Table 46-1 Public Subset Structure of LAION-5B*
+
+| Subset | Scale | Text-language Form | Engineering Meaning | Typical Use |
+| --- | ---: | --- | --- | --- |
+| LAION-2B-en | 2.32B | English | Higher language-identification confidence, filtered with English CLIP | English CLIP, image-text retrieval, English T2I data candidates |
+| LAION-2B-multi | 2.26B | More than 100 non-English languages | Uses multilingual models for image-text similarity | Multilingual image-text retrieval, multilingual vision-language pre-training |
+| LAION-1B-nolang | 1.27B | Unclear language or low confidence | Common products, places, short text, and SEO noise | Task-specific refiltering, product and place candidate pools |
+| Total | 5.85B | Mixed | Open Web image-text candidate pool | Large-scale image-text training and data research |
+
+LAION-5B's public form does not centrally host all image files; it publishes metadata and toolchains. Downstream users filter based on URLs, text, image dimensions, similarity scores, safety labels, and index information, then download or reconstruct subsets themselves.
+
+From a data-engineering perspective, LAION-5B is closer to a candidate pool than to a final training sample set. A candidate pool emphasizes coverage, indexing, and filterability; a training set emphasizes successful download, task fit, risk control, and version freezing. The same LAION-5B candidate pool can be rendered into different training views: an image-text retrieval model may retain high-CLIP-score samples; a text-to-image generation model may additionally raise aesthetic or watermark thresholds; and a document-understanding model may instead need to retain some OCR-dense samples.
+
+The final training sample is not a direct copy of the Web trace, but a structured view rendered for a target task. LAION-5B candidate records are similar: during training, they must be projected into concrete views rather than treating the full candidate pool as an undifferentiated input.
+
+## 46.3 Sample Schema: Recording Five Channels Separately
+
+Image-text candidate pools should also be modeled by channel. The Parquet metadata fields listed in the LAION-5B paper include a 64-bit integer id, image URL, text, image height and width, cosine similarity between image and text embeddings, and NSFW and watermark-detection scores. When reusing such corpora, engineering teams usually need to add governance fields such as download status, hash, authorization hints, and removal status.
+
+```mermaid
+flowchart LR
+  A["Text channel<br>text / language / text_hash"] --> E["Image-text candidate record"]
+  B["Visual channel<br>URL / size / image_hash / download_status"] --> E
+  C["Alignment channel<br>clip_model / clip_score / embedding_id"] --> E
+  D["Risk channel<br>NSFW / watermark / toxicity / license_hint"] --> E
+  E --> F["Training view / Evaluation view / Governance view"]
+```
+
+*Figure 46-1 Multi-channel schema for LAION-5B image-text candidate records. Source: original illustration based on the LAION-5B paper and LAION dataset-spec.*
+
+*Table 46-2 Image-text Candidate Record Schema*
+
+| Channel | Typical Fields | Source or Generation Method | Engineering Use |
+| --- | --- | --- | --- |
+| Text channel | `text`, `language`, `text_length`, `text_hash` | Alt text, language identification, hash | Text filtering, language bucketing, contamination detection |
+| Visual channel | `image_url`, `page_url`, `width`, `height`, `image_hash` | Common Crawl, downloader, decoder | Download reproduction, size filtering, image deduplication |
+| Alignment channel | `clip_score`, `clip_model`, `embedding_id`, `nearest_neighbors` | CLIP or multilingual CLIP encoding | Image-text relevance filtering and nearest-neighbor retrieval |
+| Risk channel | `nsfw_score`, `watermark_score`, `toxicity_score`, `license_hint` | Classifiers, dataset cards, manual rules | Safety filtering, authorization review, risk stratification |
+| Release channel | `uid`, `dataset_version`, `shard_id`, `removal_status` | Metadata generation and version system | Locate samples, respond to removals, freeze versions |
+
+A sample record for an internal training set can be written as follows:
+
+```json
+{
+  "uid": "laion5b-en-000001",
+  "dataset_version": "laion5b",
+  "image_url": "https://example.org/image.jpg",
+  "page_url": "https://example.org/page.html",
+  "text": "a red train entering a station",
+  "language": "en",
+  "width": 1024,
+  "height": 768,
+  "clip_model": "ViT-B-32",
+  "clip_score": 0.314,
+  "nsfw_score": 0.02,
+  "watermark_score": 0.11,
+  "download_status": "ok",
+  "fetch_time": "2026-03-01T10:00:00Z",
+  "image_hash": "sha256:...",
+  "text_hash": "sha256:...",
+  "removal_status": "active"
+}
+```
+
+Channelized modeling locates failure sources. If generated text does not match the image, the issue usually lies in the alignment channel. If many samples cannot be downloaded during training, the issue lies in the visual channel or release view. If the model outputs watermark-like textures, the issue may lie in the risk channel. If evaluation contamination is hard to check, the issue lies in text hashes, image hashes, and version manifests.
+
+## 46.4 From Common Crawl to Candidate Records
+
+LAION-5B construction can be divided into six stages: extract candidates from Common Crawl, download and parse images, identify language, compute image-text similarity, add risk labels, and publish metadata and indexes. This process is more like rendering Web traces into structured image-text records than simply downloading images.
+
+*Table 46-3 LAION-5B Construction Flow*
+
+| Stage | Input | Processing Action | Output | Corresponding Channel |
+| ---: | --- | --- | --- | --- |
+| 1 | Common Crawl WAT metadata | Parse HTML IMG tags and retain image candidates with alt text | `<url, text>` candidate pairs | Text channel, visual channel |
+| 2 | Image URLs and text | Distributed downloading, decoding, basic quality checks | Readable images and failure logs | Visual channel |
+| 3 | Text fields | Bucket with language-identification models | English, multilingual, and uncertain-language subsets | Text channel |
+| 4 | Images and text | Compute CLIP or multilingual CLIP embeddings and similarity | Candidate pairs with `clip_score` | Alignment channel |
+| 5 | Candidate pairs | Filter by similarity thresholds and add NSFW, watermark, toxicity, and other scores | Filtered metadata | Alignment channel, risk channel |
+| 6 | Metadata | Publish Parquet, nearest-neighbor indexes, and exploration interfaces | Searchable and filterable corpus | Release channel |
+
+The LAION-5B paper describes a CLIP cosine-similarity threshold of 0.28 for English filtering and a multilingual CLIP threshold of 0.26 for non-English image-text pairs. It also states that content filtering removes about 90% of raw image candidates, leaving close to 6B image-text pairs. This number shows that raw open Web candidate pools are enormous, but only a small share can enter the training candidate pool.
+
+### 46.4.1 Code-like Expression of Filtering Gates
+
+The following pseudocode shows the core of a LAION-5B-like image-text processing flow. It is not the official implementation; it rewrites the paper process as a data-engineering task:
+
+```python
+def build_image_text_candidates(wat_records, clip_model, lang_detector, thresholds):
+    for record in wat_records:
+        for image_url, alt_text, page_url in extract_img_alt_pairs(record):
+            if not alt_text or len(alt_text.strip()) < thresholds.min_text_chars:
+                continue
+
+            image = download_image(image_url)
+            if image.status != "ok":
+                yield failure_manifest(image_url, alt_text, page_url, image.status)
+                continue
+
+            if image.width < thresholds.min_width or image.height < thresholds.min_height:
+                continue
+
+            lang = lang_detector.predict(alt_text)
+            image_embedding = clip_model.encode_image(image.bytes)
+            text_embedding = clip_model.encode_text(alt_text)
+            score = cosine_similarity(image_embedding, text_embedding)
+
+            tau = thresholds.multilingual if lang != "en" else thresholds.english
+            if score < tau:
+                continue
+
+            yield {
+                "image_url": image_url,
+                "page_url": page_url,
+                "text": alt_text,
+                "language": lang,
+                "width": image.width,
+                "height": image.height,
+                "clip_score": score,
+                "image_hash": sha256(image.bytes),
+                "nsfw_score": nsfw_detector(image.bytes),
+                "watermark_score": watermark_detector(image.bytes),
+            }
+```
+
+This flow decomposes sample retention into a set of auditable filtering gates. Each gate should enter configuration and manifests rather than remaining only as a script parameter.
+
+Common image-text data distribution formats in the LAION ecosystem include Parquet metadata and WebDataset shards. Parquet is suitable for storing URLs, text, scores, and labels. WebDataset places images, captions, and JSON metadata into tar shards, making sequential reading by training programs convenient. A shard of 10k samples can contain file combinations such as `0.jpg`, `0.txt`, and `0.json`, where the JSON records URL, original dimensions, safety labels, and other fields.
+
+This leads to a practical principle: candidate pools and training sets must be managed in layers. The candidate pool retains as much filterable metadata as possible; the training set stores only samples that were actually selected and successfully downloaded for a given experiment. A stable mapping between the two is required, otherwise experiment metrics cannot be traced back to specific filtering rules.
+
+## 46.5 Three Views: Training, Evaluation, and Governance
+
+After training samples enter a dataloader, they are projected from the candidate-pool schema into different task views. An image-text retrieval view may be `image + text -> contrastive pair`; a T2I data-filtering view may be `text + image + aesthetic/risk filters -> generation subset`; and a safety-governance view may read only `image_url + hash + risk scores + removal_status`. This "stable candidate record, variable task view" design serves multimodal data reuse, rather than treating LAION-5B as a single training set.
+
+A data version used for one training run can be defined as:
+
+$$
+D_{\text{train}} = \operatorname{Shard}(\operatorname{Sample}(\operatorname{Filter}(D_{\text{laion}}, c), r), s)
+$$
+
+where $c$ is the filtering configuration, $r$ is the sampling random seed, and $s$ is the sharding strategy. A change in any of the three should create a new data version.
+
+### 46.5.1 Quality Evaluation and Closed-loop Repair
+
+Controllable speech data must validate semantics, style, and audio quality simultaneously; LAION-5B-like image-text data must likewise validate text, vision, alignment, risk, and reproducibility simultaneously. Looking only at CLIP scores is insufficient, and so is looking only at manual sampling. The quality system should combine automatic metrics with human review in a closed loop, sending problematic samples into redownload, refiltering, downweighting, isolation, or removal queues.
+
+```mermaid
+flowchart LR
+  A["Candidate-pool metadata"] --> B["Channelized quality checks"]
+  B --> C["Problem-sample queue"]
+  C --> D["Redownload / refilter / downweight / remove"]
+  D --> E["Freeze training view"]
+  E --> F["Evaluate with fixed protocol"]
+  F --> C
+```
+
+*Figure 46-2 Image-text candidate-pool quality evaluation and closed-loop repair. Source: original illustration based on the LAION-5B paper and DataComp benchmark design.*
+
+*Table 46-4 Quality-evaluation Metrics for Image-text Candidate Pools*
+
+| Channel | Core Question | Automatic Metrics | Human-review Focus | Handling of Failed Samples |
+| --- | --- | --- | --- | --- |
+| Text channel | Is the caption usable? | Language confidence, length, template hits, repetition rate | Whether it is advertising, filename, or SEO text | Text-rule filtering, source downweighting |
+| Visual channel | Is the image trainable? | Download success rate, size, format, hash duplicate rate | Whether it is low-resolution, truncated, thumbnail, or wrong target | Redownload, size filtering, deduplication |
+| Alignment channel | Are image and text related? | CLIP score, nearest-neighbor retrieval, human pass rate | Whether the text truly describes the image | Threshold adjustment, sample removal |
+| Risk channel | Is there high-risk content? | NSFW, watermark, toxicity, face or privacy labels | Children, medical content, trademarks, copyright, and watermark risks | Isolation, human review, disablement |
+| Release channel | Is it reproducible and removable? | Manifest coverage, URL status, hash coverage | Whether removal requests can be located | Freeze version, add hashes, build ledger |
+
+### 46.5.2 DataComp Provides a Protocol for Comparing Filtering Strategies
+
+The LAION-5B paper demonstrates dataset usability by training and reproducing models such as CLIP, GLIDE, and Stable Diffusion, and also discusses test-set overlap, data bias, and safety/ethics issues. For engineering teams, a more actionable evaluation method is to compare data filters under a fixed training protocol. DataComp provides exactly this idea: it fixes the model architecture, training hyperparameters, and downstream evaluations, and mainly changes dataset design.
+
+Let the filtering strategy be $g$, candidate pool be $D$, fixed training process be $T$, the $j$-th downstream evaluation be $b_j$, and evaluation weight be $w_j$. The overall score of a data-filtering strategy can be written as:
+
+$$
+S(g)=\sum_{j=1}^{k}w_j\cdot b_j(T(g(D)))
+$$
+
+This formula shifts the question from "do samples look clean" to "under the same training budget, does this strategy produce a better model." For LAION-5B users, this means threshold choices should not be made by intuition based only on CLIP scores or aesthetic scores; they should be placed into reproducible small-scale training experiments.
+
+## 46.6 Risk Governance and Reuse Boundaries
+
+Risks in image-text data are easier for the public to perceive and harder to fully automate. Images may contain faces, children, license plates, home environments, medical images, identity documents, trademarks, artworks, and watermarks. Even if the caption does not contain PII, the image itself may leak privacy. A public URL does not mean authorization is clear; a high CLIP score does not mean the content is safe; and a low NSFW score does not mean risk is zero.
+
+*Table 46-5 Risk-control Checklist for LAION-5B-like Image-text Data*
+
+| Risk Type | Trigger Scenario | Control Measures | Audit Evidence |
+| --- | --- | --- | --- |
+| URL decay | Images cannot be downloaded or content changes when rerun | Preserve hash, download time, failure logs, and snapshot strategy | Download manifest |
+| Caption noise | Alt text is advertising, template, or SEO text | Text rules, template detection, human sampling | Text filter report |
+| Watermark and copyright | Too many stock images, repost sites, or product images | Watermark detection, domain restrictions, license allowlist | Watermark score, source policy |
+| NSFW and minors | Classifier confidence is low or topic is high-risk | Multi-model detection, human review, conservative release | Risk review log |
+| Faces and privacy | Personal photos, medical images, identity documents | Face detection, privacy labels, removal channel | Removal ledger |
+| Evaluation contamination | Benchmark images or answers enter the candidate pool | Image hash, caption n-gram, URL-overlap checks | Eval isolation report |
+
+Table 46-5 turns risk governance into data gates. High-risk samples should not be handled only by post-training safety strategies; they should be isolated, downweighted, or removed during candidate-pool filtering. For generative-model training, watermark, copyright, face, and child-related risks require especially conservative handling.
+
+When enterprises reuse LAION-5B methods internally, they should first retain five kinds of evidence:
+
+- Data-source records, including Web source, URL, crawl time, and download status.
+- Filtering-configuration records, including CLIP model, thresholds, language-identification model, and size rules.
+- Risk-label records, including NSFW, watermark, toxicity, face, child, and privacy-related detections.
+- Training manifests, including final sample ids, shards, random seeds, and sampling proportions.
+- Governance records, including removal requests, source restrictions, known issues, and human-review results.
+
+These records determine whether downstream teams can answer the question "why did the model learn this behavior." For multimodal models, this question is usually harder than for pure-text models, because images themselves may contain risks that cannot be inferred from captions.
+
+At the same time, LAION-5B is more suitable as a methodological reference and candidate pool for open image-text data engineering than as an unfiltered package that directly enters production training. The paper authors also explicitly suggest that the current form is mainly intended for academic research and remind users that model behavior and potential biases must be reviewed before deployment.
+
+If the goal is to train a production-grade generative model, the recommended process is not to absorb the entire library, but to first define task boundaries and risk boundaries, then construct interpretable subsets from LAION-5B-like candidate pools. High-value but high-risk samples should preferably be replaced or supplemented through licensed acquisition, human recaptioning, synthetic alternatives, or compliant internal sources.
+
+## Chapter Summary
+
+LAION-5B shows how an open image-text candidate pool can move from Web URLs and alt text to a filterable, indexable, and evaluable data asset. This chapter's core conclusions are threefold.
+
+First, image-text pairs must be modeled by channel. Text, visual, alignment, risk, and release channels correspond to different failure sources. Second, a candidate pool is not a final training set. Downstream teams need to project candidate records into training, evaluation, and governance views, and freeze manifests. Third, filtering strategies must be validated through fixed training protocols. DataComp's significance is that it allows different filters to be compared under the same model, same budget, and same evaluation suite.
+
+For readers of this book, what is most worth learning from LAION-5B is not downloading more images directly, but decomposing open Web image-text relationships into checkable channels, then using quality loops, risk gates, and fixed evaluation protocols to turn candidate pools into reusable multimodal training assets.
+
+## References
+
+- Schuhmann, C., Beaumont, R., Vencu, R., Gordon, C., Wightman, R., Cherti, M., et al. (2022). LAION-5B: An open large-scale dataset for training next generation image-text models. NeurIPS 2022 Datasets and Benchmarks Track. https://arxiv.org/abs/2210.08402
+- LAION. (2022). LAION-5B: A new era of open large-scale multi-modal datasets. https://laion.ai/blog/laion-5b/
+- LAION-AI. (2022). dataset-spec. https://github.com/LAION-AI/dataset-spec
+- Gadre, S. Y., Ilharco, G., Fang, A., Hayase, J., Smyrnis, G., Nguyen, T., et al. (2023). DataComp: In search of the next generation of multimodal datasets. NeurIPS 2023 Datasets and Benchmarks Track. https://arxiv.org/abs/2304.14108
+- DataComp Team. (2026). DataComp Benchmark Documentation. https://www.datacomp.ai/dcclip/
+- ML Foundations. (2023). DataComp codebase. https://github.com/mlfoundations/datacomp

--- a/docs/zh/part12/ch44_fineweb_redpajama_dclm.md
+++ b/docs/zh/part12/ch44_fineweb_redpajama_dclm.md
@@ -1,0 +1,348 @@
+# 第44章 FineWeb 预训练语料数据工程
+
+## 摘要
+
+FineWeb 是 Hugging Face 团队基于 Common Crawl 构建的大规模英文 Web 预训练语料。它的价值不只在于规模，而在于把“如何把网页快照变成训练数据”这件事拆成了可复现的工程链路：从 WARC 原始网页读取、URL 风险过滤、Trafilatura 正文抽取、FastText 语言识别、Gopher/C4/FineWeb 质量过滤，到按 crawl 独立 MinHash 去重、PII 格式化和版本发布。FineWeb 论文同时公开了处理代码、DataTrove 处理库和消融模型，使数据处理选择可以被训练结果回验，而不是停留在人工抽检或经验判断上。
+
+FineWeb 这一章的主线是 Web 预训练语料的“炼制过程”。Common Crawl 给出的只是网页快照，离可训练 token stream 还差正文抽取、语言识别、质量过滤、去重、隐私处理和评估消融。FineWeb 的价值不只在 15T tokens 的规模，而在它把这些选择做成可执行代码和可比较实验：正文抽取和过滤要由下游训练结果验证，去重范围要看分布影响而不是只看删除比例，公开语料要同时交代数据、代码、字段注释和使用边界。
+
+## 关键词
+
+FineWeb；Common Crawl；DataTrove；WARC；Trafilatura；FastText；MinHash；质量过滤；预训练语料；数据消融
+
+## 44.0 学习目标
+
+通过本章学习，读者应能够：
+
+- 区分 Common Crawl WARC 文件、WET 文本文件、抽取后的网页正文、过滤后的 FineWeb 文档和最终 token stream。
+- 解释 FineWeb 为什么选择从 WARC 重新抽取正文，而不是直接使用 Common Crawl WET 文本。
+- 理解 FineWeb 官方处理脚本中 `WarcReader`、`URLFilter`、`Trafilatura`、`LanguageFilter`、`GopherRepetitionFilter`、`GopherQualityFilter`、`C4QualityFilter`、`FineWebQualityFilter`、`MinhashDedup*` 和 `PIIFormatter` 的数据工程位置。
+- 设计 Web 预训练文档记录 schema，使每条样本能追溯到来源、过滤、去重、token 统计和隐私处理状态。
+- 用固定模型规模、固定 token 预算、固定评测集和重复随机种子比较不同数据处理策略。
+- 将 FineWeb 的处理方式迁移到企业或研究项目时，识别版权、隐私、撤回、评测污染和跨语言迁移边界。
+
+## 场景引入
+
+一个团队准备训练 7B 参数级英文基础模型。第一版数据方案很直接：下载最近几年的 Common Crawl WET 文件，过滤掉非英文网页，做一次简单去重，然后把文本送进 tokenizer。离线抽样看起来还不错，很多页面确实是自然语言，token 数量也足够大。团队据此启动小模型预训练，却在几周后遇到三个难解释的问题。
+
+第一，模型在若干常识题上没有随训练步数稳定提升。抽样回看训练片段，团队发现不少文本其实是网页菜单、页脚、cookie 横幅、SEO 关键词列表和自动生成的站内推荐。第二，同一类模板网页在不同月份和不同站点反复出现，训练 loss 看似平稳，但模型输出越来越容易复读模板化短句。第三，法务要求定位某个域名的样本和疑似邮箱地址，数据团队却只能在已经打散的 token shard 中模糊搜索，无法还原“这条文本来自哪个 crawl dump、哪条 URL、经过哪些过滤器、是否被去重保留”。
+
+这三个问题说明，Common Crawl 只是网页快照，不是训练集。真正的数据工程任务不是“下载更多网页”，而是把每个网页样本转化为一条可追溯、可过滤、可去重、可评估、可撤回的训练记录。FineWeb 正是围绕这个问题建立的公开案例。
+
+## 44.1 Common Crawl 是网页快照，不是训练语料
+
+Common Crawl 的 WARC 文件保留网页抓取时的原始响应，包括 HTML、请求元数据和页面结构。WET 文件则是 Common Crawl 提供的文本抽取版本。对预训练数据工程来说，WET 的吸引力很强：它省去了 HTML 解析成本，体积更接近模型训练需要的文本。但 FineWeb 的实验发现，直接使用 WET 会留下过多 boilerplate、菜单文本和页面噪声，因此选择从 WARC 重新抽取正文。
+
+### 44.1.1 网页快照到训练文本的处理层
+
+从网页快照到训练文本，至少隔着五层变换。
+
+第一层是 URL 层过滤。某些域名、路径或子词模式本身就带有高风险，例如恶意站点、成人内容站点或明显垃圾页面。FineWeb 官方数据卡把 URL filtering 放在流程第一步，用 block-list 和 subword detection 移除来自恶意和 NSFW 网站的文档。
+
+第二层是正文抽取。HTML 页面不是正文，页面中会混入导航、页脚、脚本、推荐列表和广告。FineWeb 使用 Trafilatura 从 WARC 原始 HTML 中抽取主文本，并在论文中通过消融实验比较 WARC+Trafilatura 与 WET 的差异。
+
+第三层是语言识别。FineWeb 是英文语料，因此使用 FastText 语言过滤，保留英文得分达到阈值的文档。官方数据卡说明，FineWeb 移除 `en` language score 低于 0.65 的文档。
+
+第四层是质量过滤。网页文本中常见重复 n-gram、异常行长、过短行、列表化页面和格式错误。FineWeb 使用 Gopher repetition / quality filters、部分 C4 filters，以及 FineWeb 自定义过滤器共同控制这些问题。
+
+第五层是去重与隐私处理。FineWeb 使用按 crawl 独立执行的 MinHash 去重，并在公开发布时使用 PIIFormatter 匿名化邮箱和公网 IP 地址。
+
+这些步骤构成的不是“清洗脚本集合”，而是一组训练前的数据契约。每一步都应有输入、输出、失败记录和可复查的参数。
+
+### 44.1.2 过滤强度决定训练信号
+
+Web 语料清洗最容易出现两种相反错误。
+
+过滤太少时，模型会吸收模板、乱码、广告、重复页面和非自然语言。它们可能在 token 统计上贡献很大，但对下游任务没有帮助，甚至会损伤语言分布。过滤太多时，语料规模下降，内容覆盖面变窄，一些长尾知识、论坛问答和非标准写作会被误删。对预训练来说，过滤器不是越严格越好，而是要在保留 token 预算和提升训练信号之间寻找可验证的平衡。
+
+可用一个简单的训练收益函数描述这种权衡：
+
+$$
+U(F)=S_{eval}(D_F)-\lambda \cdot R_{risk}(D_F)-\mu \cdot \max(0, T_{target}-T_F)
+$$
+
+其中，$F$ 表示过滤策略，$D_F$ 是过滤后数据集，$S_{eval}$ 是固定评测协议下的模型得分，$R_{risk}$ 是隐私、版权、毒性和污染风险，$T_F$ 是保留 token 数，$T_{target}$ 是训练预算需要的 token 下限。这个公式不是 FineWeb 论文中的原始公式，而是对 FineWeb 实验思路的工程化抽象：最终选择过滤器时，不能只看样本“干净不干净”，还要看固定训练预算下模型是否变好，以及风险是否下降。
+
+## 44.2 FineWeb 的数据定义和公开形态
+
+FineWeb 的公开形态包括完整数据集、按 Common Crawl dump 切分的数据配置，以及较小的 sample 版本。官方数据卡说明，可以加载全量数据，也可以指定某个 crawl/dump；dump 名称采用 `CC-MAIN-(year)-(week number)` 格式。样本版本包括约 350B、100B 和 10B GPT-2 tokens 的随机子集，便于研究者在较低成本下复现实验或调试处理代码。
+
+*表44-1 FineWeb 公开数据形态和工程用途*
+
+| 形态 | 公开口径 | 工程用途 | 使用注意 |
+| --- | ---: | --- | --- |
+| FineWeb full dataset | 论文初版报告 15T tokens，官方数据卡持续列出后续 dump | 大规模英文 Web 预训练、数据消融、过滤策略研究 | 数据持续更新，引用规模时要说明数据卡访问时间和口径 |
+| Per-dump config | 以 `CC-MAIN-YYYY-WW` 组织 | 按时间窗口抽样、复现实验、定位分布变化 | 不同 dump 的站点覆盖和质量不同，不能默认同分布 |
+| `sample-350BT` | 约 350B GPT-2 tokens | 中等规模数据实验、去重和过滤策略验证 | 适合较大 ablation，不等于完整 FineWeb |
+| `sample-100BT` | 约 100B GPT-2 tokens | 原型训练、快速评估、成本受限实验 | 需要记录抽样来源和随机性 |
+| `sample-10BT` | 约 10B GPT-2 tokens | 管线调试、字段检查、读写性能测试 | 不适合得出最终数据质量结论 |
+
+数据来源 Hugging Face FineWeb 数据卡的下载配置、sample 版本说明和 dump 命名规则；FineWeb 论文的初版规模口径。
+
+### 44.2.1 任务定义
+
+FineWeb 的任务不是标注一个监督学习标签，而是为自回归语言模型构建预训练 token stream。给定 Common Crawl 的网页快照集合 $C=\{c_i\}$，目标是学习一条数据处理函数：
+
+$$
+P_\theta: C \rightarrow D=\{d_j\}
+$$
+
+其中每条输出文档 $d_j$ 至少包含抽取文本、来源元数据、语言信息、token 统计、过滤状态和去重状态。随后 tokenizer 将文档集合映射为训练序列：
+
+$$
+\tau(D)=\left[x_1,x_2,\ldots,x_N\right]
+$$
+
+预训练模型的标准目标仍是最小化 next-token 负对数似然：
+
+$$
+\mathcal{L}(\theta)=-\sum_{t=1}^{N}\log p_\theta(x_t|x_{<t})
+$$
+
+FineWeb 关注的是这个目标函数之前的部分：如何选择 $P_\theta$，使得同样的模型、同样的训练 token 和同样的评测集下，训练出的模型更好。
+
+FineWeb 留给工程团队的判断主要有三类。第一类是正文抽取问题。WET 文本已经是“文本”，但未必是“可训练正文”。FineWeb 用 WARC+Trafilatura 取代 WET，说明正文抽取本身需要被视为影响模型能力的核心变量。
+
+第二类是去重粒度问题。全局去重看起来更彻底，但 FineWeb 的消融结果显示，对所有 crawl 做全局 MinHash 去重并不一定更好；按 crawl 独立去重反而表现更强。这提醒数据工程团队，去重目标不是最大限度删除重复，而是删除会损害训练的重复。
+
+第三类是过滤器验证问题。FineWeb 没有只凭人工规则决定过滤器，而是训练多组数据消融模型，在固定评测集上比较分数。过滤器阈值、C4 规则取舍和自定义启发式规则，都是在训练回验中确定的。
+
+## 44.3 FineWeb 文档记录的关键字段
+
+FineWeb 官方数据卡说明，样本会带有 `language`、`language_score` 和 `token_count` 注释；这些字段分别来自语言过滤器和 GPT-2 tokenizer 统计。若在企业内部复刻 FineWeb 类流程，还需要把处理状态、来源、去重和风险字段一起保留下来。否则一旦训练结果异常，就无法判断问题来自抽取、过滤、去重还是采样。
+
+*表44-2 FineWeb 类 Web 文档记录 schema*
+
+| 字段组 | 典型字段 | 来源或生成方式 | 工程用途 |
+| --- | --- | --- | --- |
+| 来源字段 | `url`、`dump`、`warc_record_id`、`fetch_time` | WARC 元数据和读取器补充 | 追溯原始网页、定位 crawl、响应撤回 |
+| 文本字段 | `text`、`raw_html_hash`、`text_hash` | Trafilatura 抽取与哈希计算 | 支持训练读取、抽取质量检查和精确定位 |
+| 语言字段 | `language`、`language_score` | FastText LanguageFilter | 控制英文语料边界，排查语言识别误差 |
+| 质量字段 | `gopher_flags`、`c4_flags`、`fineweb_flags` | Gopher、C4 和 FineWeb filters | 解释样本为何被保留或移除 |
+| 去重字段 | `minhash_signature`、`dedup_cluster_id`、`dedup_keep` | MinHash 去重阶段 | 控制近似重复和复查被删除样本 |
+| 统计字段 | `token_count`、`char_count`、`line_count` | TokensCounter 和文档统计 | 估算训练预算，分析过滤影响 |
+| 隐私字段 | `pii_email_replaced`、`pii_ip_replaced` | PIIFormatter | 记录邮箱和公网 IP 匿名化状态 |
+
+表中 `gopher_flags`、`c4_flags`、`fineweb_flags` 等字段是作者为解释工程结构补充的字段组，不代表 FineWeb 官方数据卡逐项发布了这些列。FineWeb 官方明确发布的注释包括 `language`、`language_score` 和 `token_count`。
+
+### 44.3.1 一条样本不能只保存 text
+
+下面是一条抽象化的 FineWeb 类文档记录。它不是 FineWeb 原始样本，而是根据 FineWeb 数据卡和 DataTrove 管线整理的工程示例。
+
+```json
+{
+  "id": "CC-MAIN-2023-50/segment-x/warc-record-y",
+  "url": "https://example.org/article",
+  "dump": "CC-MAIN-2023-50",
+  "text": "<Trafilatura 抽取后的正文>",
+  "language": "en",
+  "language_score": 0.94,
+  "token_count": 1267,
+  "filters": {
+    "url_filter": "kept",
+    "gopher_repetition": "kept",
+    "gopher_quality": "kept",
+    "c4_quality": "kept",
+    "fineweb_quality": "kept"
+  },
+  "dedup": {
+    "method": "minhash",
+    "scope": "per_dump",
+    "ngram": 5,
+    "buckets": 14,
+    "hashes_per_bucket": 8,
+    "keep": true
+  },
+  "pii": {
+    "email_formatted": true,
+    "public_ip_formatted": true
+  }
+}
+```
+
+这个例子展示了 FineWeb 类语料的基本思想：`text` 是训练入口，但它不能单独解释样本质量。真正支撑复查的是来源、语言分数、过滤状态、去重范围和隐私处理记录。
+
+### 44.3.2 schema 与训练评估的关系
+
+FineWeb 的评估不是直接评估单条样本，而是评估由某个处理策略生成的数据版本。设某个处理版本 $v$ 对应数据集 $D_v$，训练得到模型 $M_v$。若评测集合为 $B=\{b_1,\ldots,b_k\}$，每个任务得分为 $s(M_v,b_i)$，则可以定义一个聚合得分：
+
+$$
+S(M_v)=\frac{1}{k}\sum_{i=1}^{k}s(M_v,b_i)
+$$
+
+FineWeb 论文采用固定模型、固定训练 token、固定评测任务、重复随机样本和不同初始化种子的方式比较数据版本。工程上可以进一步记录每个数据版本的处理 manifest：
+
+$$
+Manifest(v)=\{code\_commit, dump\_set, filter\_params, dedup\_params, tokenizer, sample\_seed\}
+$$
+
+没有这个 manifest，即使复现了评测脚本，也无法复现“到底训练了哪个数据版本”。
+
+## 44.4 FineWeb 的代码化处理流程
+
+FineWeb 的一个重要特点是处理过程有公开脚本。DataTrove 仓库中的 `examples/fineweb.py` 声明该文件用于处理和创建 FineWeb 数据集。脚本分为两大部分：先对每个 dump 做主处理，再对处理后的输出做 MinHash 去重和 PII 格式化。
+
+### 44.4.1 主处理流水线
+
+主处理流水线可抽象为以下顺序。类名来自 DataTrove 的 FineWeb 示例脚本，文字说明为本章整理。
+
+*表44-3 FineWeb 主处理流水线中的关键模块*
+
+| 顺序 | DataTrove 模块 | 输入 | 输出 | 作用 |
+| ---: | --- | --- | --- | --- |
+| 1 | `WarcReader` | Common Crawl WARC segments | 原始 HTML 文档流 | 从 `s3://commoncrawl/crawl-data/.../warc/` 读取网页快照 |
+| 2 | `URLFilter` | URL 和原始文档 | 保留或移除文档 | 移除恶意、NSFW 或 block-list 命中的来源 |
+| 3 | `Trafilatura` | 原始 HTML | 抽取正文文本 | 减少菜单、页脚和页面模板噪声 |
+| 4 | `LanguageFilter` | 文本 | 英文文档流和非英文排除日志 | 保留英文得分达到阈值的文档 |
+| 5 | `GopherRepetitionFilter` | 英文文本 | 重复模式过滤结果 | 移除重复 n-gram 和异常重复内容 |
+| 6 | `GopherQualityFilter` | 文本统计 | 质量过滤结果 | 应用 MassiveText/Gopher 风格质量规则 |
+| 7 | `C4QualityFilter` | 文本统计 | C4 规则过滤结果 | 应用 FineWeb 采用的 C4 规则子集 |
+| 8 | `FineWebQualityFilter` | 文本统计 | 自定义过滤结果 | 移除列表化、重复行和异常换行文档 |
+| 9 | `JsonlWriter` | 保留文档 | JSONL 分片 | 写出进入去重阶段的文档 |
+
+数据来源 DataTrove `examples/fineweb.py` 的导入模块和主处理 pipeline；FineWeb 数据卡的 data processing steps。
+
+主处理阶段的代码结构可以概括为：
+
+```python
+pipeline = [
+    WarcReader(common_crawl_warc_path),
+    URLFilter(...),
+    Trafilatura(favour_precision=True),
+    LanguageFilter(...),
+    GopherRepetitionFilter(...),
+    GopherQualityFilter(...),
+    C4QualityFilter(...),
+    FineWebQualityFilter(...),
+    JsonlWriter(base_processing_output)
+]
+```
+
+这段是概念化伪代码，用于说明 FineWeb 示例脚本中的模块顺序；真实参数、日志目录、S3 路径、任务数和 Slurm 资源配置以 DataTrove 仓库脚本为准。
+
+### 44.4.2 去重和隐私处理流水线
+
+FineWeb 使用 MinHash 做近似去重。MinHash 的目标是近似估计两个文档的 Jaccard 相似度。若文档 $A$ 和 $B$ 被表示为 5-gram 集合，则相似度可写为：
+
+$$
+J(A,B)=\frac{|G_5(A)\cap G_5(B)|}{|G_5(A)\cup G_5(B)|}
+$$
+
+MinHash 用多个哈希函数近似这个相似度。FineWeb 论文说明其去重参数为 5-grams、112 个哈希函数，拆成 14 个 bucket，每个 bucket 8 个 hash；任一 bucket 的 8 个 MinHash 相同即可判为重复候选。DataTrove 示例脚本中的 `MinhashConfig` 也对应 `n_grams=5`、`num_buckets=14`、`hashes_per_bucket=8`。
+
+```mermaid
+flowchart TD
+  A["主处理输出 JSONL"] --> B["MinhashDedupSignature<br>计算 5-gram MinHash 签名"]
+  B --> C["MinhashDedupBuckets<br>按 bucket 聚合候选重复"]
+  C --> D["MinhashDedupCluster<br>生成 remove_ids"]
+  D --> E["MinhashDedupFilter<br>删除重复文档"]
+  E --> F["TokensCounter<br>统计去重前后 token"]
+  F --> G["PIIFormatter<br>匿名化邮箱和公网 IP"]
+  G --> H["deduped_output<br>发布前数据分片"]
+```
+
+*图44-1 FineWeb MinHash 去重和 PII 处理流程。Source: original illustration based on Hugging Face DataTrove `examples/fineweb.py` and FineWeb dataset card.*
+
+### 44.4.3 FineWeb 按 crawl 独立去重的判断
+
+直觉上，全局去重似乎更彻底：把 96 个 crawl 放在一起，删除所有近似重复文档。FineWeb 的消融实验却给了相反信号。论文描述了一个关键现象：从最新 crawl 开始向旧 crawl 做全局去重时，旧 crawl 会被大量删除；在某个旧 snapshot 中，保留下来的 10% 数据反而比被删除的 90% 更差，包含更多广告、关键词列表和格式异常文本。最终，FineWeb 选择对每个 crawl 独立 MinHash 去重。
+
+这个结果对工程实践很重要。去重不是数学上越彻底越好，而是要看它如何改变数据分布。全局去重会让新旧 crawl 之间的时间分布、站点覆盖和重复簇结构发生复杂变化；如果只看“删除了多少重复”，可能误删更有价值的样本，保留低质量长尾。
+
+```mermaid
+flowchart LR
+  A["候选策略"] --> B["固定抽样 token"]
+  B --> C["训练同构 ablation 模型"]
+  C --> D["lighteval 固定任务评测"]
+  D --> E{"聚合得分是否提升"}
+  E -->|提升| F["保留策略并冻结参数"]
+  E -->|不提升| G["回退或重设阈值"]
+  G --> A
+```
+
+*图44-2 FineWeb 数据处理选择的消融评估回路。Source: original illustration based on FineWeb paper Section 3.1.*
+
+## 44.5 FineWeb 的数据处理选择评估
+
+FineWeb 的评估方法与一般数据集介绍不同。它把数据处理步骤当成实验变量，通过训练 ablation models 比较不同数据版本。论文说明，数据消融模型在模型参数、架构超参数、训练 token 数和训练步数上保持一致；为了降低随机抽样影响，每个数据版本训练两个模型，使用不同随机子集和不同初始化种子，然后比较平均分。
+
+### 44.5.1 固定变量
+
+FineWeb 的评估协议可以抽象为表44-4。
+
+*表44-4 FineWeb 数据消融评估协议*
+
+| 控制项 | FineWeb 论文做法 | 数据工程意义 |
+| --- | --- | --- |
+| 模型规模 | ablation 模型为 1.82B 参数，Llama 架构 | 避免模型规模变化掩盖数据差异 |
+| tokenizer | GPT-2 tokenizer | 固定 token 统计口径 |
+| 训练预算 | 过滤消融约 28B tokens，部分去重和累计改进实验为 350B tokens | 区分快速筛选和高成本验证 |
+| 重复实验 | 每个数据版本训练两个模型，随机子集和初始化种子不同 | 降低抽样和初始化噪声 |
+| 训练框架 | Nanotron | 固定训练实现 |
+| 评测框架 | lighteval | 固定评测实现 |
+| 评测任务 | CommonSense QA、HellaSwag、OpenBook QA、PIQA、SIQA、WinoGrande、ARC、MMLU | 用多任务信号评估数据处理效果 |
+
+数据来源 FineWeb paper Section 3.1 Experimental setup。
+
+若第 $v$ 个数据版本训练两次，得到模型 $M_{v,1}$ 和 $M_{v,2}$，每个模型在 $k$ 个任务上得分，则版本得分可以写为：
+
+$$
+\bar{S}_v=\frac{1}{2k}\sum_{r=1}^{2}\sum_{i=1}^{k}s(M_{v,r},b_i)
+$$
+
+这个公式同样是对 FineWeb 评估协议的工程化表达。它强调评估对象不是单个样本，而是“处理策略生成的数据版本”。
+
+过滤器不能只靠规则直觉一次决定。FineWeb 的过滤器选择可以分为三步。
+
+第一步，建立基础过滤。FineWeb 从 WARC 抽取文本后，先做 URL block-list、英文语言识别和 Gopher/MassiveText 风格质量过滤。论文报告，在对 96 个 snapshot 的 WARC 抽取文本应用这些基础步骤后，得到约 36T GPT-2 tokens 的数据。
+
+第二步，比较已有规则。FineWeb 研究 C4 规则时发现，terminal punctuation 规则单独带来明显提升，但会删除约 30% tokens；最终 FineWeb 采用除 terminal punctuation 外的 C4 规则子集，因为后者删除更少数据并取得更合适的训练收益。
+
+第三步，设计自定义过滤器。FineWeb 收集 50 多个文档级和跨文档统计指标，比较“较高质量”和“较低质量”数据分布，选择能区分两者的阈值，再用 28B token ablation runs 验证。最终被采用的自定义过滤器关注三类问题：行尾标点比例过低、重复行字符比例过高、短行比例异常。
+
+### 44.5.3 常见失败和修复动作
+
+FineWeb 的经验可以转化为一张 Web 预训练语料错误归因表。它不是 FineWeb 官方表格，而是本章根据 FineWeb 论文和数据卡整理的工程复盘。
+
+*表44-5 FineWeb 类 Web 语料常见失败与修复动作*
+
+| 错误类型 | 现象 | 可能根因 | 数据工程修复动作 |
+| --- | --- | --- | --- |
+| 页面模板残留 | 模型复读菜单、页脚、cookie 文案 | 直接使用 WET 或正文抽取质量差 | 回到 WARC，用 Trafilatura 或同类工具重新抽取，并抽样检查模板残留 |
+| 非英文混入 | 英文模型训练中出现多语乱码和混排 | 语言识别阈值过宽或段落混语未处理 | 保留 `language_score`，按分桶抽检，必要时段落级过滤 |
+| 重复簇过大 | loss 虚高稳定但下游无提升 | 模板站点、镜像站点、跨月重复 | 使用 MinHash 去重，并记录重复簇和去重范围 |
+| 全局去重伤害分布 | 删除大量旧 crawl 内容后模型不变好 | 全局去重改变时间和质量分布 | 比较 per-crawl 与 global dedup，固定训练预算回验 |
+| 过滤器过严 | token 规模下降，长尾知识被删 | 单条规则删除比例过高 | 记录每个过滤器 token removal rate，用 ablation 决定阈值 |
+| 隐私样本残留 | 邮箱、公网 IP 等可识别信息进入发布数据 | PII 处理缺失或误检漏检 | 使用 PIIFormatter 或同类规则，记录替换策略和边界 |
+
+## 44.6 公开 Web 语料的使用边界
+
+FineWeb 是开放 Web 预训练语料工程的强案例，但它不能被简单理解成“可以直接商用的一切网页文本”。公开数据集、开放代码和 ODC-By 许可证降低了研究复现门槛，却不自动消除使用者所在司法辖区、业务场景和下游模型发布中的版权、隐私、安全与撤回责任。
+
+FineWeb 适合用于英文基础模型预训练、Web 数据过滤策略研究、去重策略消融、DataTrove 类大规模文本处理管线调试，以及预训练语料版本治理教学。它尤其适合回答“某个数据处理步骤是否让模型变好”这类问题，因为 FineWeb 的公开资料提供了代码、数据卡、论文消融和评估协议。
+
+FineWeb 不适合直接回答所有语言、所有领域、所有合规环境下的训练数据问题。它主要由 Common Crawl 英文 Web 内容构成，不等价于中文语料、专业版权语料、医疗法律财务领域语料，也不等价于面向对话助手的 SFT 或偏好数据。
+
+企业复刻 FineWeb 思路时，最值得迁移的不是某个固定阈值，而是四类工程对象。
+
+第一，处理代码要版本化。`code_commit`、过滤器参数、tokenizer、抽样种子和 dump 列表都应进入 manifest。第二，过滤器要有排除日志。每个被删除样本最好能说明被哪个规则删除。第三，去重要保留范围和参数。per-dump、per-domain、global dedup 的影响不同，不能只记录“已去重”。第四，评估要固定变量。模型结构、训练 token、训练步数、评测集和随机种子不固定，数据处理结论就不可比。
+
+FineWeb 不应被用作无审查商业训练全集。对于商业模型，仍需做许可证、robots/terms、数据撤回、隐私和敏感内容审查。FineWeb 也不应被当作“高质量英文语料”的唯一标准；它的质量定义来自固定 ablation 模型和一组学术 benchmark，不必然覆盖产品真实使用中的帮助性、安全性、事实更新和指令遵循需求。
+
+对于中文或多语训练，不能直接照搬 FineWeb 的英文 FastText 阈值、英文 tokenizer 统计和英文页面格式假设。迁移时需要重新校准语言识别、繁简处理、站点模板、域名分布、低质量页面规则和评估任务。
+
+## 本章小结
+
+FineWeb 讲清楚了一个常被低估的问题：Web 预训练语料不是 Common Crawl 的下载结果，而是代码、过滤器、去重策略、评估协议和发布说明共同构成的数据资产。本章的核心结论有三点。
+
+第一，网页正文抽取是模型能力变量。FineWeb 从 WARC 使用 Trafilatura 重新抽取正文，正是因为 WET 文本会残留过多模板和菜单噪声。第二，去重策略必须用训练结果验证。FineWeb 的实验表明，全局 MinHash 去重不一定优于按 crawl 独立去重，删除更多重复不等于得到更好的训练数据。第三，过滤器选择应当进入固定评估协议。FineWeb 通过同构 ablation 模型、固定 token 预算、lighteval 评测和重复随机种子，把数据处理选择变成可复查的工程实验。
+
+对本书读者而言，FineWeb 最值得学习的不是照搬某个 token 规模，而是把预训练语料工程做成一套可追溯、可复现、可评估、可审计的系统。
+
+## 参考文献
+
+- Penedo, G., Kydlíček, H., Allal, L. B., Lozhkov, A., Mitchell, M., Raffel, C., von Werra, L., & Wolf, T. (2024). The FineWeb Datasets: Decanting the Web for the Finest Text Data at Scale. NeurIPS 2024 Datasets and Benchmarks Track. https://arxiv.org/abs/2406.17557
+- Hugging Face. (2026). HuggingFaceFW/fineweb Dataset Card. https://huggingface.co/datasets/HuggingFaceFW/fineweb
+- Hugging Face. (2026). DataTrove FineWeb Processing Script. https://github.com/huggingface/datatrove/blob/main/examples/fineweb.py
+- Penedo, G., Kydlíček, H., Cappelli, A., Sasko, M., & Wolf, T. (2024). DataTrove large scale data processing. https://github.com/huggingface/datatrove
+- Luccioni, S., & Viviano, J. (2021). What's in the Box? A Preliminary Analysis of Undesirable Content in the Common Crawl Corpus. https://arxiv.org/abs/2105.02732

--- a/docs/zh/part12/ch45_dolma_olmo_transparent_corpus.md
+++ b/docs/zh/part12/ch45_dolma_olmo_transparent_corpus.md
@@ -1,0 +1,298 @@
+# 第45章 Dolma 预训练语料透明账本
+
+## 摘要
+
+多数开放模型发布时会给出权重、推理代码和若干评测结果，但训练数据往往只留下含混的来源描述。对继续预训练、偏差分析、评测污染排查和许可审计来说，这种发布方式不够。模型出了问题，团队很难回答它见过哪些 source、这些 source 被怎样过滤、采样比例是多少、某个 benchmark 是否泄漏进训练语料，以及用户请求移除个人数据时应定位到哪个 shard。
+
+Dolma 是 Allen Institute for AI 发布的三万亿 token 级英文预训练语料，用于支撑开放语言模型研究和 OLMo 训练。它的价值不只是规模，而是把预训练语料写成一本可查账的工程记录：版本、来源、source-level statistics、sample proportion、ODC-BY 许可、原始来源条款、个人数据移除入口和 Dolma Toolkit 处理流程都被公开说明。围绕这本账，本章先从开放模型研究中的数据缺口进入，再梳理 Dolma 的版本和来源统计，随后沿 source 账本、单条文档记录和训练 manifest 拆解样本结构；最后讨论 Dolma Toolkit 如何把 tag、dedup、mix、tokenize 变成可审计动作，以及透明语料在质量控制、撤回和企业内部迁移中的边界。
+
+## 关键词
+
+Dolma；透明预训练语料；OLMo；source mix；token accounting；source card；manifest；Dolma Toolkit；ODC-BY；数据审计
+
+## 45.0 学习目标
+
+通过本章学习，读者应能够：
+
+- 解释为什么权重开放不能替代训练数据透明。
+- 读懂 Dolma 的版本、来源统计、采样比例和 ODC-BY 使用边界。
+- 区分文档记录、source card 和训练 manifest 在审计中的作用。
+- 用 token accounting 公式描述 raw tokens、filtered tokens、sample proportion 和 seen tokens 的关系。
+- 按 Dolma Toolkit 的 tag、dedup、mix、tokenize 四个动作理解透明语料的证据链。
+- 设计企业内部预训练语料的 source 账本、撤回账本、污染检查和版本冻结机制。
+
+## 45.1 问题场景：权重开放后仍然无法解释模型
+
+两个团队都拿到了同一个 7B 开放模型权重。第一个团队想继续预训练，让模型增强代码和科学问答能力；第二个团队想分析模型为什么在若干事实题上给出过时答案。权重、推理代码和部分评测脚本都能下载，但他们很快遇到同一个问题：模型到底见过什么数据，没人能回答。
+
+继续预训练团队需要知道原模型语料中代码、论文、百科、Web 和社交媒体分别占多少，避免在同类数据上重复过采样。偏差分析团队需要知道某些网页、论文、论坛讨论或 benchmark 题解是否进入过训练，判断问题来自知识缺失、采样权重、污染还是模型训练本身。没有训练语料和处理记录，所有解释都只能停留在猜测。
+
+Dolma 要解决的正是这个问题。它把英文预训练语料从不可见的数据配方，变成一组可下载、可统计、可处理、可撤回、可审计的 source。OLMo 在本章中不是并列主角，而是 Dolma 被透明训练链路消费的下游例子：它提醒我们，开放模型研究不应只开放权重，还应尽可能开放训练数据、处理工具和评估代码。
+
+### 45.1.1 开放模型研究需要数据证据
+
+“开放”有不同层次。只发布权重，可以让用户运行模型，却不能让研究者解释模型。发布训练代码，可以让用户复现训练框架，却仍然不能说明模型实际看过什么。真正支撑科学研究的数据透明，至少需要回答六类问题。
+
+- 来源问题：每个 document 来自 Common Crawl、代码仓库、论文、书籍、百科还是社交平台。
+- 版本问题：来源获取时间、处理脚本版本和过滤规则是什么。
+- 规模问题：raw tokens、filtered tokens、sampled tokens 和 seen tokens 是否一致。
+- 污染问题：评测集、题解、客户测试集是否与训练语料重叠。
+- 许可问题：数据集发布许可与原始来源条款如何共同约束使用者。
+- 撤回问题：若用户请求移除个人数据，能否定位并处理对应文档。
+
+Dolma 数据卡直接体现了这种设计取向：它列出版本、summary statistics、下载方式、许可信息，并提供个人数据移除入口。Dolma GitHub 仓库进一步给出数据和工具，使透明不只停留在论文描述中。
+
+对 Dolma 这类语料来说，透明的核心对象是账本，单条 `text` 不是唯一对象。更重要的是围绕 `text` 形成三本账。
+
+第一本是 source 账，记录某类数据来自哪里、规模多大、截止日期是什么、处理方法是什么。第二本是处理账，记录 tagger、过滤器、去重策略、mixer 和 tokenizer 如何改变原始文档。第三本是训练账，记录某次训练实际采样了哪些 source、采样比例是多少、seen tokens 如何分布到训练 step。
+
+如果这三本账断开，透明就会退化为“可下载”。数据可以下载，但不能解释；模型可以训练，但不能审计；版本可以更新，但不能比较。
+
+## 45.2 数据集概览：版本、规模与来源结构
+
+Dolma 不是单一静态文件，而是带版本演进的语料资产。Hugging Face 数据卡列出 `v1`、`v1_5`、`v1_5-sample`、`v1_6`、`v1_6-sample` 和 `v1_7` 等版本；其中 `v1_7` 用于训练 OLMo 7B-v1.7，并引入新来源、更多质量过滤和 fuzzy deduplication。
+
+*表45-1 Dolma 公开版本和用途*
+
+| 版本 | 发布时间 | 压缩体积 | 数据卡说明 | 工程用途 |
+| --- | --- | ---: | --- | --- |
+| `v1` | 2023-08-18 | 6.0 TB | Dolma 第一版 | 追溯最早公开语料形态 |
+| `v1_5` | 2023-10-31 | 6.4 TB | 用于训练 OLMo-1B，约 3T tokens | 复查 OLMo 早期训练语料 |
+| `v1_5-sample` | 2023-10-31 | 2.9 TB | 约 1.9T tokens 的样本，用于 OLMo-7B | 低于 full 版本的训练样本追踪 |
+| `v1_6` | 2024-01-31 | 5.4 TB | 在 v1.5 基础上增加部分去重和重复 n-gram 过滤 | 研究过滤和去重演进 |
+| `v1_6-sample` | 2024-01-31 | 16.4 GB | 约 10B tokens 的探索样本 | 快速调试和数据浏览 |
+| `v1_7` | 2024-04-15 | 4.5 TB | 用于训练 OLMo 7B-v1.7，新来源、更多质量过滤、fuzzy deduplication | 当前默认版本和透明训练参照 |
+
+数据来源 Hugging Face `allenai/dolma` 数据卡 Versions 小节。
+
+### 45.2.1 v1.6 来源结构
+
+Dolma 的来源覆盖 Web、代码、论文、社交媒体、书籍和百科。为了避免不同版本混淆，表45-2 使用数据卡中 v1.6 summary statistics 的大类统计。v1.7 的来源更加细分，新增 Refined Web、StarCoder、arXiv、StackExchange、Flan、OpenWebMath、Algebraic Stack、MegaWika 等 source；后续写作或实验应明确使用哪个版本。
+
+*表45-2 Dolma v1.6 来源统计*
+
+| 来源 | 文档类型 | UTF-8 bytes | 文档数 | Unicode words | Llama tokens |
+| --- | --- | ---: | ---: | ---: | ---: |
+| Common Crawl | web pages | 9,022 GB | 3,370M | 1,775B | 2,281B |
+| The Stack | code | 1,043 GB | 210M | 260B | 411B |
+| C4 | web pages | 790 GB | 364M | 153B | 198B |
+| Reddit | social media | 339 GB | 377M | 72B | 89B |
+| PeS2o | STEM papers | 268 GB | 38.8M | 50B | 70B |
+| Project Gutenberg | books | 20.4 GB | 0.056M | 4.0B | 6.0B |
+| Wikipedia and Wikibooks | encyclopedic | 16.2 GB | 6.2M | 3.7B | 4.3B |
+| Total | mixed | 11,519 GB | 4,367M | 2,318B | 3,059B |
+
+数据来源 Hugging Face `allenai/dolma` 数据卡 Summary Statistics v1.6。表中 GB、M、B 均沿用数据卡口径。
+
+表45-2 不应只被读成规模展示。它提示三类工程事实。
+
+第一，Dolma 是 source mix，而不是单一 Web dump。Common Crawl 占比很高，但代码、论文、社交媒体、书籍和百科都以不同形式进入语料。模型能力变化不能只笼统归因于“Web 数据更多”。
+
+第二，不同统计口径服务不同问题。UTF-8 bytes 适合估算存储和处理成本，document count 适合观察样本颗粒度，Unicode words 和 Llama tokens 则更接近训练预算。把这些口径混在一起，会让数据规模讨论失真。
+
+第三，版本之间不能直接横比。v1.6 和 v1.7 的来源拆分、过滤规则和 sample proportion 不同。如果一个模型用 v1.7 训练，不能只拿 v1.6 的大类表解释训练行为。
+
+## 45.3 以 source 账本拆解一条透明链路
+
+本节不从单条文本开讲，而是从 Dolma 的 source 账本拆解透明预训练语料的链路。这里的“样本”不是一张图或一道题，而是一条从 source 到文档、再到训练 manifest 的证据路径。
+
+### 45.3.1 从 source 到 document
+
+Dolma 的任务不是给每条文本标注监督标签，而是让训练消费记录可以被复原。设 source 集合为 $S=\{s_1,\ldots,s_m\}$，每个 source 经过处理函数 $P_s$ 后得到文档集合 $D_s$：
+
+$$
+D_s=P_s(R_s, C_s)
+$$
+
+其中 $R_s$ 是原始来源，$C_s$ 是该 source 的处理配置，包括 tagger、过滤器、去重策略、采样比例和 tokenizer。最终训练语料是多个 source 的混合：
+
+$$
+D=\bigcup_{s \in S} Sample(D_s, r_s)
+$$
+
+Dolma 的透明性体现在：$S$、$R_s$、$C_s$、$r_s$ 和版本信息都尽量被公开记录。这样模型训练不再只是“用了三万亿 token”，而是可以追踪到哪些 source 贡献了多少、如何处理、如何采样。
+
+### 45.3.2 token 账要看训练实际消费量
+
+多来源语料最容易被误读的是 token 规模。一个 source 的 raw tokens 很大，不代表它在训练中贡献同等比例；过滤、去重、sample proportion 和多轮 epoch 都会改变最终 seen tokens。
+
+可以把某个 source $s$ 在训练中的实际贡献写成：
+
+$$
+T^{seen}_s = T^{filtered}_s \times r_s \times e_s
+$$
+
+其中，$T^{filtered}_s$ 是过滤后的 token 数，$r_s$ 是采样比例，$e_s$ 是训练中被重复看到的 epoch 或等价采样次数。训练 mix 中该 source 的比例为：
+
+$$
+p_s=\frac{T^{seen}_s}{\sum_j T^{seen}_j}
+$$
+
+Dolma v1.7 数据卡中同时列出 source token 数和 sample proportion，正是为了让使用者区分“数据集里有什么”和“训练实际看了多少”。
+
+### 45.3.3 一条文档的三层读法
+
+透明语料不是把 `text` 打包上传就结束。至少需要三层记录：单条文档记录、source card 和训练版本 manifest。单条文档用于训练和定位，source card 用于解释数据来源和处理规则，训练 manifest 用于复现某次模型训练实际消费的数据。
+
+*表45-3 Dolma 类透明语料记录 schema*
+
+| 层级 | 典型字段 | 来源或生成方式 | 工程用途 |
+| --- | --- | --- | --- |
+| 文档级 | `id`、`source`、`text`、`text_hash` | 数据读取和哈希计算 | 定位样本、去重、训练读取 |
+| 文档级 | `created_at`、`url_or_origin`、`license_hint` | 原始 source 元数据 | 授权复核和时间追踪 |
+| 文档级 | `language_tag`、`toxicity_tag`、`perplexity_score` | Dolma Toolkit taggers 或自定义 tagger | 质量过滤和风险分桶 |
+| source 级 | `source_name`、`source_version`、`raw_size`、`filtered_size` | source card 与统计脚本 | 解释数据组成 |
+| source 级 | `dedup_policy`、`filter_config`、`sample_proportion` | Dolma mixer 和处理配置 | 复现 source mix |
+| 训练级 | `dolma_version`、`tokenizer`、`sample_seed`、`seen_tokens` | 训练 manifest | 复现实验和解释指标变化 |
+| 治理级 | `removal_status`、`known_limitations`、`release_constraints` | 数据卡和治理记录 | 处理撤回、偏差和使用边界 |
+
+表中字段是作者根据 Dolma 数据卡、Dolma Toolkit 文档和透明训练审计需求整理的工程 schema，不表示 Dolma 官方逐项发布了这些字段。
+
+下面是一个抽象化的 Dolma 类文档记录，用于说明透明语料如何把样本、source 和训练版本连接起来。
+
+```json
+{
+  "id": "dolma-v1_7/common-crawl/doc-000001",
+  "source": "Dolma's CC",
+  "source_version": "v1_7",
+  "text": "<document text>",
+  "text_hash": "sha256:...",
+  "tags": {
+    "language": "en",
+    "toxicity_bucket": "low",
+    "perplexity_bucket": "normal"
+  },
+  "processing": {
+    "tagger_config": "dolma-toolkit-config-x",
+    "dedup_policy": "fuzzy_dedup",
+    "sample_proportion": 0.5
+  },
+  "training_manifest": {
+    "tokenizer": "OLMo tokenizer version",
+    "dolma_version": "v1_7",
+    "included_in_run": true
+  }
+}
+```
+
+这条记录不能只看单层字段。放到 Dolma 中，文档层、source 层和训练层必须能相互指回。若文档有 `source` 但没有 source card，只能定位样本，不能解释来源；若 source card 有统计但没有训练 manifest，只能说明数据集里有什么，不能说明模型实际看了什么；若 manifest 有采样比例但没有文档 hash，撤回和污染检查就会断链。
+
+## 45.4 Dolma Toolkit 让证据链可执行
+
+Dolma GitHub 仓库说明，Dolma 同时是数据集和工具包。Dolma Toolkit 支持单机、集群和云环境，内置语言检测、毒性检测、perplexity scoring，以及 Gopher、C4、OpenWebText 等常见过滤 recipe；去重部分使用 Rust Bloom filter 加速。
+
+### 45.4.1 四个动作对应四类证据
+
+Dolma Toolkit 文档把数据整理概括为四个动作：tag、dedup、mix、tokenize。它们不是孤立脚本，而是证据链的生成器：tag 记录文档属性，dedup 记录保留和删除，mix 记录采样比例，tokenize 记录进入训练的 token 口径。
+
+*表45-4 Dolma Toolkit 处理动作与证据输出*
+
+| 顺序 | 动作 | 官方文档说明 | 证据输出 | 主要风险 |
+| ---: | --- | --- | --- | --- |
+| 1 | Taggers | 给文档 span 打语言、毒性、perplexity 等属性标签 | 文档质量标签和风险标签 | tagger 版本变化会改变过滤结果 |
+| 2 | Deduplication | 基于内容或元数据对文档去重 | 去重策略、保留优先级、删除记录 | 跨 source 去重会改变 source mix |
+| 3 | Mixer | 根据属性值移除、过滤或混合文档 | sample proportion、source mix、数据版本 | sample proportion 不透明会导致 token accounting 错误 |
+| 4 | Tokenization | 使用 Hugging Face 兼容 tokenizer | token 计数、tokenizer 版本、训练流 | tokenizer 变化会改变 token 数和训练预算 |
+
+数据来源 Dolma Toolkit documentation README。
+
+```mermaid
+flowchart LR
+  A["Source card<br>origin / license / cutoff"] --> B["Taggers<br>quality and risk evidence"]
+  B --> C["Deduplication<br>keep / remove evidence"]
+  C --> D["Mixer<br>sample proportion"]
+  D --> E["Tokenization<br>seen-token accounting"]
+  E --> F["Training manifest<br>run-level evidence"]
+```
+
+*图45-1 Dolma 透明语料证据链。Source: original illustration based on AllenAI Dolma Toolkit documentation.*
+
+这里要注意工具链和人工审计的边界。工具链能稳定地产生统计、标签、hash 和 manifest，但它不能替代所有审计。许可边界、PII removal、评测污染和 source 代表性仍需要人工规则、抽样复核或专门的检测任务介入。
+
+这也是 Dolma 类透明语料和普通“清洗脚本集合”的区别。普通脚本只回答“我删掉了什么”，透明工具链还要回答“为什么删、删后分布怎么变、训练是否真的受益、后续能否撤回”。如果某个处理动作不能留下可解释证据，它就很难支撑透明训练。
+
+## 45.5 评估从最高分转向可归因
+
+透明语料的评估重点不是“最高分”，而是“分数变化能不能解释”。Dolma 这类 source-level 语料让模型评估不再停在 leaderboard 上，而是能顺着训练日志回到 source、版本和采样比例。
+
+### 45.5.1 source ablation 定位能力来源
+
+如果要判断某个 source 是否影响模型能力，可以做 source ablation。设完整训练得到模型 $M_{all}$，移除 source $s$ 后得到模型 $M_{-s}$，在任务集合 $B$ 上的平均差异为：
+
+$$
+\Delta_s=\frac{1}{|B|}\sum_{b \in B} \left[score(M_{all}, b)-score(M_{-s}, b)\right]
+$$
+
+当 $\Delta_s$ 在代码任务、科学问答或长文本任务上明显变化时，数据团队才能把能力变化回溯到 source mix，而不是泛泛归因于“模型参数”。
+
+```mermaid
+flowchart TD
+  A["Source statistics<br>tokens / documents / cutoff"] --> B["Sample proportion"]
+  B --> C["Seen tokens by source"]
+  C --> D["Training run"]
+  D --> E["Checkpoint evaluation"]
+  E --> F["Source-level diagnosis"]
+  F --> B
+```
+
+*图45-2 Dolma source mix 与训练诊断回路。Source: original illustration based on Dolma dataset card and OLMo training use.*
+
+### 45.5.2 诊断清单
+
+*表45-5 Dolma 类透明语料评估和诊断表*
+
+| 评估问题 | 所需记录 | 指标或证据 | 可能动作 |
+| --- | --- | --- | --- |
+| 某类能力来自哪个 source | source mix、sample proportion、seen tokens | source ablation、任务得分差 $\Delta_s$ | 调整 source 权重或补充数据 |
+| 某个评测是否被污染 | 文档 hash、n-gram index、eval set hash | overlap rate、contamination span | 删除污染样本并冻结新版本 |
+| 训练 loss 异常波动 | batch source 记录、tokenizer 版本 | source-specific loss、token distribution | 回查采样器和 source shard |
+| 社交媒体风险升高 | toxicity tag、PII tag、source card | risk tag rate、人工抽检 | 收紧过滤或降低采样比例 |
+| 版本间不可比 | dolma_version、filter_config、dedup_policy | manifest diff | 固定版本或重跑对照实验 |
+
+### 45.5.3 常见失败模式
+
+*表45-6 Dolma 类透明语料常见失败与修复动作*
+
+| 失败模式 | 表现 | 可能根因 | 治理方式 |
+| --- | --- | --- | --- |
+| source mix 漂移 | 新版本某类任务突然退化 | sample proportion 或过滤规则变化 | 比较 manifest diff，回滚或分层重采样 |
+| token accounting 不一致 | 报告规模与训练 seen tokens 对不上 | raw、filtered、sampled tokens 混用 | 同时报告 raw、filtered、sampled、seen tokens |
+| 跨来源重复 | 论文摘要、百科镜像、代码片段重复出现 | 只做 source 内去重 | 增加跨 source 去重并记录保留优先级 |
+| 评测污染 | benchmark 分数异常偏高 | Web 或论坛含题目和题解 | 建立 eval hash/n-gram 去污染索引 |
+| 撤回不可定位 | PII removal 请求无法处理 | 缺少 source/id/hash 映射 | 建立 removal ledger 和 shard 反向索引 |
+| 许可边界模糊 | 误把 ODC-BY 当作原始来源授权 | 忽略原始 source terms | 在 source card 中保留原始条款和限制 |
+
+这些失败模式说明，透明语料的质量不只取决于文本是否干净。一个透明训练样本至少要同时通过三类检查：source 是否可解释，处理动作是否可复现，训练消费是否可追踪。缺少任何一类检查，数据都可能成为“公开但不可审计”的语料。
+
+## 45.6 透明语料的复用边界
+
+Dolma 适合用于开放语言模型预训练研究、source mix 实验、透明数据治理教学、训练数据审计方法验证，以及企业内部 manifest 设计参照。它尤其适合回答“训练数据如何影响模型能力和局限”这类研究问题，因为它把数据、数据卡和处理工具一起公开。
+
+Dolma 不应被理解为所有来源都可无条件商用。Hugging Face 数据卡说明 Dolma 按 ODC-BY 发布，同时使用者仍受原始数据来源的许可协议和使用条款约束。也就是说，Dolma 的发布许可不自动抹平 Common Crawl、Reddit、代码、论文、书籍等原始来源的边界。
+
+企业内部通常不能公开训练数据，但可以迁移 Dolma 的透明做法。最低可行版本包括：
+
+- 为每个 source 建 source card，记录来源、版本、许可、获取时间、过滤规则和限制。
+- 为每个训练版本冻结 manifest，记录 source mix、sample proportion、tokenizer、filter_config、dedup_policy 和 sample_seed。
+- 为主要 source 建 validation split，支持 source-specific loss 和 source ablation。
+- 为评测集、客户测试集和线上问题库建立去污染索引。
+- 建立 removal ledger，使 URL、document id 或 text hash 能映射到训练 shard。
+
+同时，Dolma 不适合直接作为中文、多语或垂直行业语料的质量标准。它主要是英文预训练语料，迁移到中文、医疗、法律或金融场景时，需要重新定义 source、许可、过滤器和评估任务。Dolma 也不应被用来证明开放语料天然安全。透明的意义是缺陷可见、可定位、可修复，而不是宣称缺陷不存在。
+
+## 本章小结
+
+Dolma 把预训练语料从不可见的数据配方推进到有账可查的数据资产。本章的核心结论有三点。
+
+第一，透明预训练语料的基本单位不是单条 `text`，而是能连接 source、处理配置、采样比例和训练 manifest 的文档记录。第二，source mix 必须用 token accounting 解释，不能只报告原始规模。第三，Dolma Toolkit 的 tag、dedup、mix、tokenize 四个动作，为企业内部构建可复现训练语料提供了清晰模板。
+
+对本书读者而言，Dolma 最值得迁移的不是某个具体 source，也不是三万亿 token 的规模，而是把训练数据留下证据的方式。只要 source、处理动作、采样比例、训练 manifest 和治理记录能连成链，预训练语料才具备继续研究、错误归因和长期维护的基础。
+
+## 参考文献
+
+- Soldaini, L., Kinney, R., Bhagia, A., Schwenk, D., Atkinson, D., Authur, R., et al. (2024). Dolma: an Open Corpus of Three Trillion Tokens for Language Model Pretraining Research. ACL 2024. https://arxiv.org/abs/2402.00159
+- Allen Institute for AI. (2023). Ai2 Dolma: 3 trillion token open corpus for language model pretraining. https://allenai.org/blog/dolma-3-trillion-tokens-open-llm-corpus-9a0ff4b8da64
+- AllenAI. (2026). allenai/dolma Dataset Card. https://huggingface.co/datasets/allenai/dolma
+- AllenAI. (2026). Dolma Dataset and Toolkit Repository. https://github.com/allenai/dolma
+- AllenAI. (2026). Dolma Toolkit Documentation. https://github.com/allenai/dolma/blob/main/docs/README.md
+- Groeneveld, D., Beltagy, I., Walsh, P., Bhagia, A., Kinney, R., Tafjord, O., et al. (2024). OLMo: Accelerating the Science of Language Models. https://arxiv.org/abs/2402.00838

--- a/docs/zh/part12/ch46_laion_datacomp_image_text.md
+++ b/docs/zh/part12/ch46_laion_datacomp_image_text.md
@@ -1,0 +1,282 @@
+# 第46章 LAION-5B 图文候选池与筛选通道
+
+## 摘要
+
+图文基础语料和纯文本语料最大的差异，不在于多了图片文件，而在于样本被拆成了多个必须同时成立的通道。文本通道要说明图片被怎样描述，视觉通道要说明图片是否能下载、尺寸和内容是否可用，对齐通道要说明图文是否相关，风险通道要说明是否含有水印、NSFW、毒性、隐私或授权风险。任何一个通道失效，图文对都可能不适合训练。
+
+LAION-5B 是由 Common Crawl 衍生的大规模图文候选池。它从网页 WAT 元数据中解析 IMG 标签和 alt text，通过语言识别、图片下载、CLIP 或多语言 CLIP 相似度过滤、水印与 NSFW 检测、近邻索引和 Parquet 元数据发布，将开放网页图文对组织成可查询、可筛选、可复查的数据资产。本章把 LAION-5B 拆成文本、视觉、对齐、风险和发布五条通道，再讨论候选池如何被筛选成训练视图、评测视图和治理视图。DataComp 不作为本章主线数据集，而作为评估协议参照，用来说明如何在固定模型和固定下游评测中比较不同图文筛选策略。
+
+## 关键词
+
+LAION-5B；图文对；Common Crawl；alt text；CLIP 过滤；多通道 schema；WebDataset；Parquet；DataComp；风险治理
+
+## 46.0 学习目标
+
+通过本章学习，读者应能够：
+
+- 解释为什么网页图文对必须分成文本、视觉、对齐、风险和发布通道检查。
+- 理解 LAION-5B 的英文、多语言和无语言子集结构。
+- 设计可追踪图文样本 schema，覆盖 URL、文本、图片尺寸、CLIP 分数、安全标签和撤回状态。
+- 用 CLIP 相似度和阈值函数描述图文筛选闸门。
+- 区分候选池视图、训练视图、评测视图和治理视图。
+- 用 DataComp 式固定训练协议比较图文筛选策略。
+- 识别公开 URL、版权、人脸、儿童、NSFW、水印和链接衰减风险。
+
+## 46.1 开篇问题场景：图文对需要通道化筛选
+
+一个多模态团队准备训练视觉语言模型。他们从网页里抽取了几十亿条 `<image_url, alt_text>`，然后让下载脚本按 URL 拉取图片。第一轮抽检很快暴露问题：很多 URL 已经失效；不少 alt text 是文件名、广告词、SEO 关键词或无关段落；有些图片分辨率过低、带水印、包含成人内容、人脸、儿童照片、医疗影像或版权标识。更麻烦的是，图文看起来相关也不等于适合训练。一张产品图配上“点击购买”，对视觉概念学习帮助有限；一张个人照片配上姓名、地址或社交账号，则会把隐私风险带入模型。
+
+如果把这类数据压成一个自由文本 prompt，后续几乎无法定位问题。模型生成水印，是视觉通道的问题；模型学到广告模板，是文本通道的问题；图文检索能力差，是对齐通道的问题；训练后出现人脸、儿童或版权争议，是风险通道和治理通道的问题。LAION-5B 的工程启发在于，它不是把网页图片简单打包，而是把候选图文关系拆成一组可筛选字段，让下游团队按任务目标重新组合。
+
+普通图片数据集通常以图像文件和人工标签为中心，样本边界相对稳定。图文候选池则不同。图片可能随 URL 失效或被替换，alt text 可能不是 caption，网页上下文可能和图片弱相关，安全标签可能随检测器版本变化。样本不是一个静态对象，而是一条需要持续验证的网页关系。
+
+这种关系至少有三种脆弱性。第一是时间脆弱性，URL 会过期，图片会更新，网页会重定向。第二是语义脆弱性，alt text 可能服务无障碍、SEO 或模板展示，不一定描述图片。第三是治理脆弱性，公开可访问的 URL 不代表授权清晰，也不代表没有人脸、儿童、医疗、商标或水印风险。
+
+### 46.1.2 CLIP 分数只解决图文相关性的一部分
+
+LAION-5B 的核心过滤信号来自图文 embedding 的余弦相似度。设图片编码器为 $f_I$，文本编码器为 $f_T$，图片为 $i$，文本为 $t$，则图文相似度可以写为：
+
+$$
+\operatorname{sim}(i,t)=\frac{f_I(i)\cdot f_T(t)}{\|f_I(i)\|\|f_T(t)\|}
+$$
+
+相似度阈值过滤可以抽象为：
+
+$$
+\operatorname{keep}(i,t)=\mathbb{1}[\operatorname{sim}(i,t)\ge \tau_{\ell}]
+$$
+
+其中 $\tau_{\ell}$ 可以按语言或子集设定。这个过滤能提高图文相关性，但它不是事实正确性、安全性或授权合规性的证明。高 CLIP 分数的图片仍可能含水印、人脸、成人内容、隐私信息或版权风险；低 CLIP 分数的样本也可能是图表、文档页、医学图像等对某些任务有价值的内容。
+
+## 46.2 数据集概览：子集规模与公开形态
+
+LAION-5B 论文报告它包含 5.85B 个 CLIP 过滤后的图文对，其中英文子集约 2.32B，多语言子集约 2.26B，语言不确定子集约 1.27B。这个拆分很重要，因为语言识别、CLIP 模型、过滤阈值和下游任务都会影响样本价值。
+
+*表46-1 LAION-5B 的公开子集结构*
+
+| 子集 | 规模 | 文本语言形态 | 工程含义 | 典型用途 |
+| --- | ---: | --- | --- | --- |
+| LAION-2B-en | 2.32B | 英文 | 语言识别置信度较高，使用英文 CLIP 过滤 | 英文 CLIP、图文检索、英文 T2I 数据候选 |
+| LAION-2B-multi | 2.26B | 100 多种非英文语言 | 使用多语言模型处理图文相似度 | 多语言图文检索、多语言视觉语言预训练 |
+| LAION-1B-nolang | 1.27B | 语言不明确或低置信度 | 常见商品、地点、短文本和 SEO 噪声 | 特定任务再筛选、商品和地点类候选池 |
+| Total | 5.85B | 混合 | 开放网页图文候选池 | 大规模图文训练和数据研究 |
+
+LAION-5B 的公开形态不是把所有图片文件集中托管起来，而是发布元数据和工具链。下游使用者根据 URL、文本、图像尺寸、相似度分数、安全标签和索引信息筛选，再自行下载或重建子集。
+
+从数据工程角度看，LAION-5B 更接近候选池，而不是某一次训练的最终样本集合。候选池强调覆盖、索引和可筛选；训练集强调下载成功、任务适配、风险控制和版本冻结。同一个 LAION-5B 候选池，可以渲染出不同训练视图：图文检索模型可能保留高 CLIP 分数样本，文本到图像生成模型可能额外提高美学或水印阈值，文档理解模型则可能反而需要保留部分 OCR 密集样本。
+
+最终训练样本不是网页 trace 的直接复制，而是按目标任务渲染出来的结构化视图。LAION-5B 的候选记录也一样，训练时要投影成具体视图，不能把全量候选池当成一个无差别输入。
+
+## 46.3 样本 schema：五条通道分开记录
+
+图文候选池也应分通道建模。LAION-5B 论文列出的 Parquet 元数据字段包括 64 位整数 id、图片 URL、文本、图片高宽、图文 embedding 的余弦相似度，以及 NSFW 和水印检测分数。工程团队在复用这类语料时，通常还需要补充下载、hash、授权线索和撤回状态等治理字段。
+
+```mermaid
+flowchart LR
+  A["文本通道<br>text / language / text_hash"] --> E["图文候选记录"]
+  B["视觉通道<br>URL / size / image_hash / download_status"] --> E
+  C["对齐通道<br>clip_model / clip_score / embedding_id"] --> E
+  D["风险通道<br>NSFW / watermark / toxicity / license_hint"] --> E
+  E --> F["训练视图 / 评测视图 / 治理视图"]
+```
+
+*图46-1 LAION-5B 图文候选记录的多通道 schema。Source: original illustration based on LAION-5B paper and LAION dataset-spec.*
+
+*表46-2 图文候选记录 schema*
+
+| 通道 | 典型字段 | 来源或生成方式 | 工程用途 |
+| --- | --- | --- | --- |
+| 文本通道 | `text`、`language`、`text_length`、`text_hash` | alt text、语言识别、哈希 | 文本过滤、语言分桶、污染检测 |
+| 视觉通道 | `image_url`、`page_url`、`width`、`height`、`image_hash` | Common Crawl、下载器、解码器 | 下载复现、尺寸过滤、图像去重 |
+| 对齐通道 | `clip_score`、`clip_model`、`embedding_id`、`nearest_neighbors` | CLIP 或多语言 CLIP 编码 | 图文相关性过滤和近邻检索 |
+| 风险通道 | `nsfw_score`、`watermark_score`、`toxicity_score`、`license_hint` | 分类器、数据卡、人工规则 | 安全过滤、授权复核、风险分层 |
+| 发布通道 | `uid`、`dataset_version`、`shard_id`、`removal_status` | 元数据生成和版本系统 | 定位样本、响应撤回、冻结版本 |
+
+一个内部训练集的样本记录可以写成如下形式：
+
+```json
+{
+  "uid": "laion5b-en-000001",
+  "dataset_version": "laion5b",
+  "image_url": "https://example.org/image.jpg",
+  "page_url": "https://example.org/page.html",
+  "text": "a red train entering a station",
+  "language": "en",
+  "width": 1024,
+  "height": 768,
+  "clip_model": "ViT-B-32",
+  "clip_score": 0.314,
+  "nsfw_score": 0.02,
+  "watermark_score": 0.11,
+  "download_status": "ok",
+  "fetch_time": "2026-03-01T10:00:00Z",
+  "image_hash": "sha256:...",
+  "text_hash": "sha256:...",
+  "removal_status": "active"
+}
+```
+
+分通道建模能够定位失败来源。若模型生成文本与图片不匹配，问题通常在对齐通道；若训练时大量样本无法下载，问题在视觉通道或发布视图；若模型输出带水印纹理，问题可能在风险通道；若评测污染难以排查，问题在文本 hash、image hash 和版本 manifest。
+
+## 46.4 从 Common Crawl 到候选记录
+
+LAION-5B 的构建可以拆成六个阶段：从 Common Crawl 中抽取候选，下载和解析图片，识别语言，计算图文相似度，添加风险标签，发布元数据和索引。这个过程更像将网页 trace 渲染成结构化图文记录，而不是简单下载图片。
+
+*表46-3 LAION-5B 构建流程*
+
+| 阶段 | 输入 | 处理动作 | 输出 | 对应通道 |
+| ---: | --- | --- | --- | --- |
+| 1 | Common Crawl WAT 元数据 | 解析 HTML IMG 标签，保留带 alt text 的图片候选 | `<url, text>` 候选对 | 文本通道、视觉通道 |
+| 2 | 图片 URL 和文本 | 分布式下载、解码、基础质量检查 | 可读取图片和失败日志 | 视觉通道 |
+| 3 | 文本字段 | 使用语言识别模型分桶 | 英文、多语言、语言不确定子集 | 文本通道 |
+| 4 | 图片和文本 | 计算 CLIP 或多语言 CLIP embedding 与相似度 | 带 `clip_score` 的候选对 | 对齐通道 |
+| 5 | 候选对 | 按相似度阈值过滤，并添加 NSFW、水印、毒性等分数 | 过滤后元数据 | 对齐通道、风险通道 |
+| 6 | 元数据 | 发布 Parquet、近邻索引和探索接口 | 可查询、可筛选语料 | 发布通道 |
+
+LAION-5B 论文描述的英文过滤阈值为 CLIP 余弦相似度 0.28，非英文图文对使用多语言 CLIP 阈值 0.26。论文也指出，内容过滤会移除约 90% 的原始图片候选，最后保留下接近 6B 的图文对。这个数字说明，开放网页候选池的原始规模很大，但真正能进入训练候选池的比例并不高。
+
+### 46.4.1 筛选闸门的代码化表达
+
+下面的伪代码展示了 LAION-5B 类图文处理流程的核心。它不是官方实现，而是把论文流程改写为数据工程任务：
+
+```python
+def build_image_text_candidates(wat_records, clip_model, lang_detector, thresholds):
+    for record in wat_records:
+        for image_url, alt_text, page_url in extract_img_alt_pairs(record):
+            if not alt_text or len(alt_text.strip()) < thresholds.min_text_chars:
+                continue
+
+            image = download_image(image_url)
+            if image.status != "ok":
+                yield failure_manifest(image_url, alt_text, page_url, image.status)
+                continue
+
+            if image.width < thresholds.min_width or image.height < thresholds.min_height:
+                continue
+
+            lang = lang_detector.predict(alt_text)
+            image_embedding = clip_model.encode_image(image.bytes)
+            text_embedding = clip_model.encode_text(alt_text)
+            score = cosine_similarity(image_embedding, text_embedding)
+
+            tau = thresholds.multilingual if lang != "en" else thresholds.english
+            if score < tau:
+                continue
+
+            yield {
+                "image_url": image_url,
+                "page_url": page_url,
+                "text": alt_text,
+                "language": lang,
+                "width": image.width,
+                "height": image.height,
+                "clip_score": score,
+                "image_hash": sha256(image.bytes),
+                "nsfw_score": nsfw_detector(image.bytes),
+                "watermark_score": watermark_detector(image.bytes),
+            }
+```
+
+这个流程把是否保留样本拆成若干可审计的筛选闸门。每个闸门都应进入配置和 manifest，而不应只停留在脚本参数里。
+
+LAION 生态中常见的图文数据分发方式包括 Parquet 元数据和 WebDataset 分片。Parquet 适合保存 URL、文本、分数和标签；WebDataset 则把图片、caption 和 json 元数据放入 tar 分片，方便训练程序顺序读取。一个 10k 样本的 shard 可以包含 `0.jpg`、`0.txt`、`0.json` 这样的文件组合，json 中记录 URL、原始尺寸和安全标签等字段。
+
+这带来一个实际原则：候选池和训练集要分层管理。候选池保留尽可能多的可筛选元数据，训练集只保存某次实验真正选择并下载成功的样本。两者之间必须有稳定映射，否则实验指标无法回查到具体过滤规则。
+
+## 46.5 三种视图：训练、评测与治理
+
+训练样本进入 dataloader 后，会从候选池 schema 投影成不同任务视图。图文检索视图可以是 `image + text -> contrastive pair`；T2I 数据筛选视图可以是 `text + image + aesthetic/risk filters -> generation subset`；安全治理视图则可能只读取 `image_url + hash + risk scores + removal_status`。这种“候选记录稳定、任务视图可变”的设计，服务的是多模态数据复用，而不是把 LAION-5B 当成单一训练集。
+
+可以把一次训练使用的数据定义为：
+
+$$
+D_{\text{train}} = \operatorname{Shard}(\operatorname{Sample}(\operatorname{Filter}(D_{\text{laion}}, c), r), s)
+$$
+
+其中 $c$ 是过滤配置，$r$ 是采样随机种子，$s$ 是分片策略。三者任意一个变化，都应产生新的数据版本。
+
+### 46.5.1 质量评估与闭环修复
+
+可控语音数据需要同时验收语义、风格和音频质量；LAION-5B 类图文数据也需要同时验收文本、视觉、对齐、风险和复现性。单独看 CLIP 分数不够，单独看人工抽检也不够。质量系统应把自动指标与人工复核组合成闭环，问题样本进入重下载、重过滤、降权、隔离或剔除队列。
+
+```mermaid
+flowchart LR
+  A["候选池元数据"] --> B["通道化质量检查"]
+  B --> C["问题样本队列"]
+  C --> D["重下载 / 重过滤 / 降权 / 剔除"]
+  D --> E["冻结训练视图"]
+  E --> F["固定协议评测"]
+  F --> C
+```
+
+*图46-2 图文候选池质量评估与闭环修复。Source: original illustration based on LAION-5B paper and DataComp benchmark design.*
+
+*表46-4 图文候选池质量评估指标*
+
+| 通道 | 核心问题 | 自动指标 | 人工复核要点 | 不合格处理 |
+| --- | --- | --- | --- | --- |
+| 文本通道 | caption 是否可用 | 语言置信度、长度、模板命中、重复率 | 是否为广告、文件名、SEO 文本 | 文本规则过滤、source 降权 |
+| 视觉通道 | 图片是否可训练 | 下载成功率、尺寸、格式、hash 重复率 | 是否低清、截断、缩略图、非目标图片 | 重下载、尺寸过滤、去重 |
+| 对齐通道 | 图文是否相关 | CLIP 分数、近邻检索、人工通过率 | 文本是否真正描述图片 | 阈值调整、样本剔除 |
+| 风险通道 | 是否存在高风险内容 | NSFW、水印、毒性、人脸或隐私标签 | 儿童、医疗、商标、版权和水印风险 | 隔离、人工复核、禁用 |
+| 发布通道 | 是否可复现和撤回 | manifest 覆盖率、URL 状态、hash 覆盖率 | 撤回请求能否定位 | 冻结版本、补 hash、建立 ledger |
+
+### 46.5.2 DataComp 提供筛选策略比较协议
+
+LAION-5B 论文用训练和复现 CLIP、GLIDE、Stable Diffusion 等模型来展示数据集的可用性，也讨论了测试集重叠、数据偏差和安全伦理问题。对于工程团队来说，更可操作的评估方法是把数据筛选器放到固定训练协议中比较。DataComp 正好提供了这种思路：固定模型架构、训练超参数和下游评测，主要改变数据集设计。
+
+设过滤策略为 $g$，候选池为 $D$，固定训练过程为 $T$，第 $j$ 个下游评测为 $b_j$，评测权重为 $w_j$，则一个数据过滤策略的总分可以写为：
+
+$$
+S(g)=\sum_{j=1}^{k}w_j\cdot b_j(T(g(D)))
+$$
+
+这个公式把问题从“样本看起来是否干净”转成“在同样训练预算下是否得到更好的模型”。对 LAION-5B 的使用者来说，这意味着不要只按 CLIP 分数或美学分数拍脑袋选阈值，而要把阈值选择放进可复现的小规模训练实验中。
+
+## 46.6 风险治理与复用边界
+
+图文数据的风险更容易被公众感知，也更难完全自动化处理。图片中可能出现人脸、儿童、车牌、家庭环境、医疗影像、身份证件、商标、艺术作品和水印。caption 即使不含 PII，图像本身也可能泄露隐私。URL 公开不等于授权清晰，CLIP 分数高不等于内容安全，NSFW 分数低也不等于风险为零。
+
+*表46-5 LAION-5B 类图文数据风险控制清单*
+
+| 风险类型 | 触发场景 | 控制措施 | 审计证据 |
+| --- | --- | --- | --- |
+| URL 衰减 | 复跑时图片不可下载或内容替换 | 保存 hash、下载时间、失败日志和快照策略 | download manifest |
+| caption 噪声 | alt text 为广告、模板或 SEO 文本 | 文本规则、模板检测、人工抽检 | text filter report |
+| 水印和版权 | 图库、转载站、商品图过多 | 水印检测、域名限制、授权白名单 | watermark score、source policy |
+| NSFW 与未成年人 | 分类器低置信或高风险主题 | 多模型检测、人工复核、保守发布 | risk review log |
+| 人脸和隐私 | 个人照片、医疗影像、身份证件 | 人脸检测、隐私标签、撤回通道 | removal ledger |
+| 评测污染 | benchmark 图片或答案进入候选池 | image hash、caption n-gram、URL overlap 检查 | eval isolation report |
+
+表46-5 将风险治理落实为数据门禁。高风险样本不能只靠训练后安全策略兜底，而要在候选池筛选阶段就被隔离、降权或剔除。对生成模型训练来说，水印、版权、人脸和儿童相关风险尤其需要保守处理。
+
+企业内部复用 LAION-5B 方法时，应先保留五类证据：
+
+- 数据来源记录，包括网页来源、URL、抓取时间和下载状态。
+- 过滤配置记录，包括 CLIP 模型、阈值、语言识别模型和尺寸规则。
+- 风险标签记录，包括 NSFW、水印、毒性、人脸、儿童和隐私相关检测。
+- 训练 manifest，包括最终样本 id、shard、随机种子和采样比例。
+- 治理记录，包括撤回请求、来源限制、已知问题和人工复核结果。
+
+这些记录决定了下游团队能否回答“模型为什么学到这个样子”。对于多模态模型，这个问题通常比纯文本模型更难，因为图片本身可能含有无法从 caption 中看出的风险。
+
+同时，LAION-5B 更适合作为开放图文数据工程的方法参照和候选池，而不是未经筛选直接进入生产训练的数据包。论文作者也明确建议当前形式主要用于学术研究，并提醒部署系统前必须审查模型行为和潜在偏差。
+
+如果目标是训练生产级生成模型，推荐流程不是整库吸收，而是先定义任务边界和风险边界，再从 LAION-5B 类候选池中构造可解释子集。高收益但高风险的样本，应优先通过授权采买、人工重标注、合成替代或内部合规来源补齐。
+
+## 本章小结
+
+LAION-5B 展示了开放图文候选池如何从网页 URL 和 alt text 变成可筛选、可索引、可评估的数据资产。本章的核心结论有三点。
+
+第一，图文对必须分通道建模。文本、视觉、对齐、风险和发布通道分别对应不同失败来源。第二，候选池不是最终训练集。下游团队需要把候选记录投影成训练视图、评测视图和治理视图，并冻结 manifest。第三，筛选策略必须通过固定训练协议验证。DataComp 的意义在于让不同过滤器在同一模型、同一预算和同一评测集合下比较。
+
+对本书读者而言，LAION-5B 最值得学习的不是直接下载更多图片，而是把开放网页图文关系拆成可检查通道，再用质量闭环、风险门禁和固定评测协议把候选池变成可复用的多模态训练资产。
+
+## 参考文献
+
+- Schuhmann, C., Beaumont, R., Vencu, R., Gordon, C., Wightman, R., Cherti, M., et al. (2022). LAION-5B: An open large-scale dataset for training next generation image-text models. NeurIPS 2022 Datasets and Benchmarks Track. https://arxiv.org/abs/2210.08402
+- LAION. (2022). LAION-5B: A new era of open large-scale multi-modal datasets. https://laion.ai/blog/laion-5b/
+- LAION-AI. (2022). dataset-spec. https://github.com/LAION-AI/dataset-spec
+- Gadre, S. Y., Ilharco, G., Fang, A., Hayase, J., Smyrnis, G., Nguyen, T., et al. (2023). DataComp: In search of the next generation of multimodal datasets. NeurIPS 2023 Datasets and Benchmarks Track. https://arxiv.org/abs/2304.14108
+- DataComp Team. (2026). DataComp Benchmark Documentation. https://www.datacomp.ai/dcclip/
+- ML Foundations. (2023). DataComp codebase. https://github.com/mlfoundations/datacomp


### PR DESCRIPTION
## Summary


- 12节后新增第"44"章：FineWeb 预训练语料数据工程，围绕 Common Crawl 到可训练 Web 语料的处理链路、schema、过滤去重、消融评估与使用边界展开。
- 新增第"45"章：Dolma 预训练语料透明账本，重点讲解 source 账本、training manifest、Dolma Toolkit、可审计训练数据链路与复用边界。
- 新增第"46"章：LAION-5B 图文候选池与筛选通道，覆盖图文候选记录 schema、Common Crawl 到候选池流程、训练/评测/治理视图和风险控制。

## Scope

- 未修改目录、导航、出版台账或后续章号。